### PR TITLE
popToTop before nav when saving contact thru prompt

### DIFF
--- a/src/containers/SendTo/index.tsx
+++ b/src/containers/SendTo/index.tsx
@@ -308,6 +308,7 @@ export default function SendTo(props: { navigation?: any, route?: any }) {
   function onModalHide() {
     hideModal();
     void intercomAnalyticsLog('save_as_a_contact_yes');
+    props.navigation.popToTop();
     props.navigation.navigate(C.screenTitle.OPTIONS);
     setTimeout(() => {
       props.navigation.navigate(C.screenTitle.OPTIONS, { screen: C.screenTitle.CREATE_CONTACT, params: { additionalAddress: { chain: ChainNameToContactsChainNameMapping[tokenData.chainDetails?.name], toAddress: addressText } } });
@@ -333,9 +334,10 @@ export default function SendTo(props: { navigation?: any, route?: any }) {
   function onModalHideWithNo() {
     hideModal();
     void intercomAnalyticsLog('save_as_a_contact_no');
+    props.navigation.popToTop();
+    props.navigation.navigate(C.screenTitle.OPTIONS);
     setTimeout(() => {
       props.navigation.navigate(C.screenTitle.OPTIONS, { screen: C.screenTitle.ACTIVITIES, initial: false });
-      props.navigation.popToTop();
     }, MODAL_HIDE_TIMEOUT_250);
   }
 


### PR DESCRIPTION
This change will pop the portfolio stack till top, so that when returning to portfolio after nav, we end up in portfolio rather than sendTo screen.