### PR TITLE
feat: :sparkles: txn tab chain based filter and redesign

### DIFF
--- a/src/components/v2/portfolioTokenItem.tsx
+++ b/src/components/v2/portfolioTokenItem.tsx
@@ -73,7 +73,7 @@ const PortfolioTokenItem = ({
     return (
       <CyDView
         className={
-          'flex flex-row justify-evenly items-center bg-secondaryBackgroundColor px-[15px]'
+          'flex flex-row justify-evenly items-center bg-secondaryBackgroundColor'
         }
       >
         <CyDView>
@@ -258,8 +258,8 @@ const PortfolioTokenItem = ({
             source={
               item?.logoUrl
                 ? {
-                    uri: item.logoUrl,
-                  }
+                  uri: item.logoUrl,
+                }
                 : randomColor[Math.floor(Math.random() * randomColor.length)]
             }
             resizeMode='contain'
@@ -312,16 +312,16 @@ const PortfolioTokenItem = ({
               <CyDTokenValue className='text-[18px] font-bold'>
                 {item.actualUnbondingBalance !== undefined
                   ? item.totalValue +
-                    item.actualStakedBalance +
-                    item.actualUnbondingBalance
+                  item.actualStakedBalance +
+                  item.actualUnbondingBalance
                   : '...'}
               </CyDTokenValue>
               <CyDTokenAmount className='text-[14px]'>
                 {item.stakedBalanceTotalValue !== undefined &&
-                item.unbondingBalanceTotalValue !== undefined
+                  item.unbondingBalanceTotalValue !== undefined
                   ? item.actualBalance +
-                    item.stakedBalanceTotalValue +
-                    item.unbondingBalanceTotalValue
+                  item.stakedBalanceTotalValue +
+                  item.unbondingBalanceTotalValue
                   : '...'}
               </CyDTokenAmount>
             </CyDView>

--- a/src/containers/Portfolio/components/FilterBar.tsx
+++ b/src/containers/Portfolio/components/FilterBar.tsx
@@ -9,7 +9,7 @@ interface FilterBarProps {
 const FilterBar = ({ setFilterModalVisible }: FilterBarProps) => {
 
   return (
-    <CyDView className="w-full items-end px-[10px] py-[5px] border-sepratorColor rounded-t-[24px] border">
+    <CyDView className="w-full items-end px-[10px] py-[5px] border-sepratorColor border-t-[0.5px]">
       <CyDTouchView onPress={() => {
         setFilterModalVisible(true);
       }}>

--- a/src/containers/Portfolio/components/FilterBar.tsx
+++ b/src/containers/Portfolio/components/FilterBar.tsx
@@ -9,7 +9,7 @@ interface FilterBarProps {
 const FilterBar = ({ setFilterModalVisible }: FilterBarProps) => {
 
   return (
-    <CyDView className="w-full items-end px-[10px] py-[5px] border-sepratorColor border-t-[0.5px]">
+    <CyDView className="w-full items-end px-[10px] py-[5px] border-sepratorColor rounded-t-[24px] border">
       <CyDTouchView onPress={() => {
         setFilterModalVisible(true);
       }}>

--- a/src/containers/Portfolio/components/transactionInfoModal.tsx
+++ b/src/containers/Portfolio/components/transactionInfoModal.tsx
@@ -118,11 +118,11 @@ export default function TransactionInfoModal({
               {fromTokenIcon
                 ? <CyDImage
                   source={{ uri: fromTokenIcon }}
-                  className={'w-[36px] h-[36px] rounded-full'}
+                  className={'w-[25px] h-[25px] rounded-full'}
                 />
                 : <CyDImage
                   source={AppImages.UNKNOWN_TXN_TOKEN}
-                  className={'w-[36px] h-[36px] rounded-full'}
+                  className={'w-[25px] h-[25px] rounded-full'}
                 />}
               {fromToken
                 ? (
@@ -130,7 +130,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{fromToken}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -142,7 +142,7 @@ export default function TransactionInfoModal({
                   <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                   {blockchain && (
                     <CyDView className='flex flex-row justify-center items-center'>
-                      <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                      <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
                       <CyDText className='text-[12px] mt-[2px]'>
                         {chain}
                       </CyDText>
@@ -158,11 +158,11 @@ export default function TransactionInfoModal({
               {toTokenIcon
                 ? <CyDImage
                   source={{ uri: toTokenIcon }}
-                  className={'w-[36px] h-[36px] rounded-full'}
+                  className={'w-[25px] h-[25px] rounded-full'}
                 />
                 : <CyDImage
                   source={AppImages.UNKNOWN_TXN_TOKEN}
-                  className={'w-[36px] h-[36px] rounded-full'}
+                  className={'w-[25px] h-[25px] rounded-full'}
                 />}
               {toToken
                 ? (
@@ -170,7 +170,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{toToken}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -182,7 +182,7 @@ export default function TransactionInfoModal({
                   <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                   {blockchain && (
                     <CyDView className='flex flex-row justify-center items-center'>
-                      <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                      <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
                       <CyDText className='text-[12px] mt-[2px]'>
                         {chain}
                       </CyDText>
@@ -198,7 +198,7 @@ export default function TransactionInfoModal({
             <CyDView className='flex flex-row items-center'>
               {tokenIcon && <CyDImage
                 source={{ uri: tokenIcon }}
-                className={'w-[36px] h-[36px]'}
+                className={'w-[25px] h-[25px]'}
               />}
               {token
                 ? (
@@ -206,7 +206,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] ml-[10px] mt-[2px] font-bold text-activityFontColor'>{token}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[10px] w-[10px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -219,7 +219,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] ml-[10px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[10px] w-[10px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -237,17 +237,17 @@ export default function TransactionInfoModal({
               {tokenIcon
                 ? <CyDImage
                   source={{ uri: tokenIcon }}
-                  className={'w-[36px] h-[36px] rounded-full'}
+                  className={'w-[25px] h-[25px] rounded-full'}
                 />
                 : <CyDImage
                   source={AppImages.UNKNOWN_TXN_TOKEN}
-                  className={'w-[36px] h-[36px] rounded-full'}
+                  className={'w-[25px] h-[25px] rounded-full'}
                 />}
               <CyDView className='flex flex-col ml-[5px] items-start'>
                 <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{token || t('UNKNOWN')}</CyDText>
                 {blockchain && (
                   <CyDView className='flex flex-row justify-center items-center '>
-                    <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                    <CyDFastImage className='h-[10px] w-[10px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
                     <CyDText className='text-[12px] mt-[2px]'>
                       {chain}
                     </CyDText>

--- a/src/containers/Portfolio/components/transactionInfoModal.tsx
+++ b/src/containers/Portfolio/components/transactionInfoModal.tsx
@@ -130,7 +130,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{fromToken}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -142,7 +142,7 @@ export default function TransactionInfoModal({
                   <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                   {blockchain && (
                     <CyDView className='flex flex-row justify-center items-center'>
-                      <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                      <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
                       <CyDText className='text-[12px] mt-[2px]'>
                         {chain}
                       </CyDText>
@@ -170,7 +170,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{toToken}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -182,7 +182,7 @@ export default function TransactionInfoModal({
                   <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                   {blockchain && (
                     <CyDView className='flex flex-row justify-center items-center'>
-                      <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                      <CyDFastImage className='h-[18px] w-[18px] mr-[5px]' resizeMode='contain' source={chainImg} />
                       <CyDText className='text-[12px] mt-[2px]'>
                         {chain}
                       </CyDText>
@@ -206,7 +206,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] ml-[10px] mt-[2px] font-bold text-activityFontColor'>{token}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -219,7 +219,7 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] ml-[10px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                        <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
                         <CyDText className='text-[12px] mt-[2px]'>
                           {chain}
                         </CyDText>
@@ -244,10 +244,10 @@ export default function TransactionInfoModal({
                   className={'w-[36px] h-[36px] rounded-full'}
                 />}
               <CyDView className='flex flex-col ml-[5px] items-start'>
-                <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{token ? token : t('UNKNOWN')}</CyDText>
+                <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{token || t('UNKNOWN')}</CyDText>
                 {blockchain && (
                   <CyDView className='flex flex-row justify-center items-center '>
-                    <CyDFastImage className='h-[20px] w-[20px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                    <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
                     <CyDText className='text-[12px] mt-[2px]'>
                       {chain}
                     </CyDText>

--- a/src/containers/Portfolio/components/transactionInfoModal.tsx
+++ b/src/containers/Portfolio/components/transactionInfoModal.tsx
@@ -118,11 +118,11 @@ export default function TransactionInfoModal({
               {fromTokenIcon
                 ? <CyDImage
                   source={{ uri: fromTokenIcon }}
-                  className={'w-[25px] h-[25px] rounded-[8px]'}
+                  className={'w-[36px] h-[36px] rounded-full'}
                 />
                 : <CyDImage
                   source={AppImages.UNKNOWN_TXN_TOKEN}
-                  className={'w-[25px] h-[25px] rounded-[8px]'}
+                  className={'w-[36px] h-[36px] rounded-full'}
                 />}
               {fromToken
                 ? (
@@ -130,10 +130,10 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{fromToken}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                          <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
-                          <CyDText className='text-[12px] mt-[2px]'>
-                            {chain}
-                          </CyDText>
+                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                        <CyDText className='text-[12px] mt-[2px]'>
+                          {chain}
+                        </CyDText>
                       </CyDView>
                     )}
                   </CyDView>
@@ -141,13 +141,13 @@ export default function TransactionInfoModal({
                 : <CyDView className='flex flex-col items-start ml-[5px]'>
                   <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                   {blockchain && (
-                      <CyDView className='flex flex-row justify-center items-center'>
-                          <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
-                          <CyDText className='text-[12px] mt-[2px]'>
-                            {chain}
-                          </CyDText>
-                      </CyDView>
-                    )}
+                    <CyDView className='flex flex-row justify-center items-center'>
+                      <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                      <CyDText className='text-[12px] mt-[2px]'>
+                        {chain}
+                      </CyDText>
+                    </CyDView>
+                  )}
                 </CyDView>}
             </CyDView>
             <CyDImage
@@ -158,11 +158,11 @@ export default function TransactionInfoModal({
               {toTokenIcon
                 ? <CyDImage
                   source={{ uri: toTokenIcon }}
-                  className={'w-[25px] h-[25px] rounded-[8px]'}
+                  className={'w-[36px] h-[36px] rounded-full'}
                 />
                 : <CyDImage
                   source={AppImages.UNKNOWN_TXN_TOKEN}
-                  className={'w-[25px] h-[25px] rounded-[8px]'}
+                  className={'w-[36px] h-[36px] rounded-full'}
                 />}
               {toToken
                 ? (
@@ -170,10 +170,10 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{toToken}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                          <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
-                          <CyDText className='text-[12px] mt-[2px]'>
-                            {chain}
-                          </CyDText>
+                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                        <CyDText className='text-[12px] mt-[2px]'>
+                          {chain}
+                        </CyDText>
                       </CyDView>
                     )}
                   </CyDView>
@@ -181,13 +181,13 @@ export default function TransactionInfoModal({
                 : <CyDView className='flex flex-col items-start ml-[5px]'>
                   <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                   {blockchain && (
-                      <CyDView className='flex flex-row justify-center items-center'>
-                          <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
-                          <CyDText className='text-[12px] mt-[2px]'>
-                            {chain}
-                          </CyDText>
-                      </CyDView>
-                    )}
+                    <CyDView className='flex flex-row justify-center items-center'>
+                      <CyDFastImage className='h-[20px] w-[20px] mr-[5px]' resizeMode='contain' source={chainImg} />
+                      <CyDText className='text-[12px] mt-[2px]'>
+                        {chain}
+                      </CyDText>
+                    </CyDView>
+                  )}
                 </CyDView>}
             </CyDView>
           </CyDView>
@@ -198,7 +198,7 @@ export default function TransactionInfoModal({
             <CyDView className='flex flex-row items-center'>
               {tokenIcon && <CyDImage
                 source={{ uri: tokenIcon }}
-                className={'w-[25px] h-[25px]'}
+                className={'w-[36px] h-[36px]'}
               />}
               {token
                 ? (
@@ -206,10 +206,10 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] ml-[10px] mt-[2px] font-bold text-activityFontColor'>{token}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                          <CyDFastImage className='h-[10px] w-[10px] mr-[5px] rounded-[8px]' resizeMode='contain' source={chainImg} />
-                          <CyDText className='text-[12px] mt-[2px]'>
-                            {chain}
-                          </CyDText>
+                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                        <CyDText className='text-[12px] mt-[2px]'>
+                          {chain}
+                        </CyDText>
                       </CyDView>
                     )}
                   </CyDView>
@@ -219,10 +219,10 @@ export default function TransactionInfoModal({
                     <CyDText className='text-[16px] ml-[10px] mt-[2px] font-bold text-activityFontColor'>{t('UNKNOWN')}</CyDText>
                     {blockchain && (
                       <CyDView className='flex flex-row justify-center items-center'>
-                          <CyDFastImage className='h-[10px] w-[10px] mr-[5px] rounded-[8px]' resizeMode='contain' source={chainImg} />
-                          <CyDText className='text-[12px] mt-[2px]'>
-                            {chain}
-                          </CyDText>
+                        <CyDFastImage className='h-[20px] w-[20px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                        <CyDText className='text-[12px] mt-[2px]'>
+                          {chain}
+                        </CyDText>
                       </CyDView>
                     )}
                   </CyDView>
@@ -237,23 +237,23 @@ export default function TransactionInfoModal({
               {tokenIcon
                 ? <CyDImage
                   source={{ uri: tokenIcon }}
-                  className={'w-[25px] h-[25px] rounded-[8px]'}
+                  className={'w-[36px] h-[36px] rounded-full'}
                 />
                 : <CyDImage
                   source={AppImages.UNKNOWN_TXN_TOKEN}
-                  className={'w-[25px] h-[25px] rounded-[8px]'}
+                  className={'w-[36px] h-[36px] rounded-full'}
                 />}
-                <CyDView className='flex flex-col ml-[5px] items-start'>
-                  <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{token ? token : t('UNKNOWN')}</CyDText>
-                  {blockchain && (
-                      <CyDView className='flex flex-row justify-center items-center '>
-                          <CyDFastImage className='h-[10px] w-[10px] mr-[5px] rounded-[8px]' resizeMode='contain' source={chainImg} />
-                          <CyDText className='text-[12px] mt-[2px]'>
-                            {chain}
-                          </CyDText>
-                      </CyDView>
-                    )}
-                </CyDView>
+              <CyDView className='flex flex-col ml-[5px] items-start'>
+                <CyDText className='text-[16px] mt-[2px] font-bold text-activityFontColor'>{token ? token : t('UNKNOWN')}</CyDText>
+                {blockchain && (
+                  <CyDView className='flex flex-row justify-center items-center '>
+                    <CyDFastImage className='h-[20px] w-[20px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                    <CyDText className='text-[12px] mt-[2px]'>
+                      {chain}
+                    </CyDText>
+                  </CyDView>
+                )}
+              </CyDView>
             </CyDView>
             <CyDView className='max-w-[30%] flex justify-center items-end pr-[18px]'>
               <CyDText className='text-[14px] font-bold text-activityFontColor'>{formatAmount(value)}</CyDText>

--- a/src/containers/Portfolio/scenes/txnScene.tsx
+++ b/src/containers/Portfolio/scenes/txnScene.tsx
@@ -46,23 +46,23 @@ const GetTransactionItemIcon = ({ type, status, tokenIcon, fromTokenIcon, toToke
   switch (type) {
     case TransactionType.SEND:
       transactionIcon = status === 'completed' ? (tokenIcon ? { uri: tokenIcon } : AppImages.UNKNOWN_TXN_TOKEN) : AppImages.TXN_SEND_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
+      return (<CyDFastImage className='h-[25px] w-[25px] rounded-full' resizeMode='contain' source={transactionIcon} />);
     case TransactionType.RECEIVE:
       transactionIcon = status === 'completed' ? (tokenIcon ? { uri: tokenIcon } : AppImages.UNKNOWN_TXN_TOKEN) : AppImages.TXN_RECEIVE_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
+      return (<CyDFastImage className='h-[25px] w-[25px] rounded-full' resizeMode='contain' source={transactionIcon} />);
     case TransactionType.SWAP:
       const fromTokenImg = fromTokenIcon ? { uri: fromTokenIcon } : AppImages.UNKNOWN_TXN_TOKEN;
       const toTokenImg = toTokenIcon ? { uri: toTokenIcon } : AppImages.UNKNOWN_TXN_TOKEN;
 
       return (
-        <CyDView className='h-[36px] w-[36px] justify-center items-center' style={{ position: 'relative', backgroundColor: 'transparent' }}>
+        <CyDView className='h-[25px] w-[25px] justify-center items-center' style={{ position: 'relative', backgroundColor: 'transparent' }}>
           <CyDFastImage
-            className='h-[36px] w-[36px] absolute right-[8px] rounded-full'
+            className='h-[25px] w-[25px] absolute right-[8px] rounded-full'
             resizeMode='contain'
             source={fromTokenImg}
           />
           <CyDFastImage
-            className='h-[36px] w-[36px] absolute top-[10px] left-[8px] rounded-full'
+            className='h-[25px] w-[25px] absolute top-[10px] left-[8px] rounded-full'
             resizeMode='contain'
             source={toTokenImg}
           />
@@ -71,10 +71,10 @@ const GetTransactionItemIcon = ({ type, status, tokenIcon, fromTokenIcon, toToke
 
     case TransactionType.SELF:
       transactionIcon = status === 'completed' ? AppImages.TXN_SELF_SUCCESS : AppImages.TXN_SELF_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
+      return (<CyDFastImage className='h-[25px] w-[25px] rounded-full' resizeMode='contain' source={transactionIcon} />);
     default:
       transactionIcon = status === 'completed' ? AppImages.TXN_DEFAULT_SUCCESS : AppImages.TXN_DEFAULT_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
+      return (<CyDFastImage className='h-[25px] w-[25px] rounded-full' resizeMode='contain' source={transactionIcon} />);
   }
 };
 
@@ -320,33 +320,32 @@ const TxnScene = ({
     const [formattedAmount, amountColour] = getTransactionItemAmountDetails(activity.type, activity.value, activity.token, activity.additionalData?.fromTokenValue ?? '', activity.additionalData?.fromToken ?? '');
     const title = activity.type ? activity?.type.charAt(0).toUpperCase() + activity.type.slice(1) : 'Unknown';
     return (
-      <CyDView className="border-x border-sepratorColor">
-        {shouldRenderDate && <CyDView className={clsx(' border-sepratorColor p-[5px] justify-center')}>
-          <CyDText className='font-bold text-[14px]'>{formatedDay}</CyDText>
+      <CyDView>
+        {shouldRenderDate && <CyDView className={clsx(' border-sepratorColor pl-[10px] pr-[30px] py-[10px] justify-center', { 'mt-[28px]': index !== 0 })}>
+          <CyDText className='font-bold text-[16px]'>{formatedDay}</CyDText>
         </CyDView>}
-        <CyDTouchView className={clsx('flex flex-row items-center py-[10px] border-b-[0.5px] border-sepratorColor px-[10px]', { 'rounded-t-[24px] border-t-[0.5px]': shouldRenderDate, 'rounded-b-[24px]': (nextTransactionFormatedDay !== formatedDay) })}
+        <CyDTouchView className={clsx('flex flex-row items-center py-[10px] border-b-[0.5px] border-x border-sepratorColor pl-[10px] pr-[30px]', { 'rounded-t-[24px] border-t-[0.5px]': shouldRenderDate, 'rounded-b-[24px]': (nextTransactionFormatedDay !== formatedDay) })}
           onPress={() => {
             setTransactionInfoParams(activity);
           }}
         >
           <GetTransactionItemIcon type={activity.type} status={activity.status} tokenIcon={activity.tokenIcon} fromTokenIcon={activity.additionalData?.fromTokenIcon} toTokenIcon={activity.additionalData?.toTokenIcon} />
           <CyDView className="flex flex-row justify-between">
-            <CyDView className='px-[10px] w-[50%] items-start justify-start'>
-              <CyDView className='flex flex-row w-full justify-start items-center'>
-                <CyDText className='font-extrabold text-[14px]'>{title}</CyDText>
+            <CyDView className='px-[10px] items-start justify-start'>
+              <CyDView className='flex flex-row justify-center items-center'>
+                <CyDText className='font-bold text-[16px]'>{title}</CyDText>
               </CyDView>
-              <CyDView className='flex flex-row w-full justify-start items-center'>
-                <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+              <CyDView className='flex flex-row justify-center items-center'>
+                <CyDFastImage className='h-[10px] w-[10px] mr-[5px]' resizeMode='contain' source={chainImg} />
                 <RenderTransactionItemDetails type={activity.type} from={activity.from} to={activity.to} />
               </CyDView>
             </CyDView>
-            <CyDView className='flex w-[40%] items-end self-end'>
+            <CyDView className='flex flex-1 items-end self-end'>
               <CyDText numberOfLines={1} className={`${amountColour} mt-[3px]`}>{formattedAmount}</CyDText>
-              <CyDText className='text-[14px]'>{formatDate}</CyDText>
+              <CyDText>{formatDate}</CyDText>
             </CyDView>
           </CyDView>
-        </CyDTouchView>
-      </CyDView>
+        </CyDTouchView></CyDView>
     );
 
   }

--- a/src/containers/Portfolio/scenes/txnScene.tsx
+++ b/src/containers/Portfolio/scenes/txnScene.tsx
@@ -46,10 +46,10 @@ const GetTransactionItemIcon = ({ type, status, tokenIcon, fromTokenIcon, toToke
   switch (type) {
     case TransactionType.SEND:
       transactionIcon = status === 'completed' ? (tokenIcon ? { uri: tokenIcon } : AppImages.UNKNOWN_TXN_TOKEN) : AppImages.TXN_SEND_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />)
+      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
     case TransactionType.RECEIVE:
       transactionIcon = status === 'completed' ? (tokenIcon ? { uri: tokenIcon } : AppImages.UNKNOWN_TXN_TOKEN) : AppImages.TXN_RECEIVE_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />)
+      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
     case TransactionType.SWAP:
       const fromTokenImg = fromTokenIcon ? { uri: fromTokenIcon } : AppImages.UNKNOWN_TXN_TOKEN;
       const toTokenImg = toTokenIcon ? { uri: toTokenIcon } : AppImages.UNKNOWN_TXN_TOKEN;
@@ -71,10 +71,10 @@ const GetTransactionItemIcon = ({ type, status, tokenIcon, fromTokenIcon, toToke
 
     case TransactionType.SELF:
       transactionIcon = status === 'completed' ? AppImages.TXN_SELF_SUCCESS : AppImages.TXN_SELF_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />)
+      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
     default:
       transactionIcon = status === 'completed' ? AppImages.TXN_DEFAULT_SUCCESS : AppImages.TXN_DEFAULT_ERROR;
-      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />)
+      return (<CyDFastImage className='h-[36px] w-[36px] rounded-[50px]' resizeMode='contain' source={transactionIcon} />);
   }
 };
 
@@ -314,14 +314,14 @@ const TxnScene = ({
 
     let shouldRenderDate = false;
     if (formatedDay !== previousTransactionFormatedDay) {
-      dateCheck = moment.unix(activity.timestamp).format('MMM DD, YYYY')
+      dateCheck = moment.unix(activity.timestamp).format('MMM DD, YYYY');
       shouldRenderDate = true;
     }
     const [formattedAmount, amountColour] = getTransactionItemAmountDetails(activity.type, activity.value, activity.token, activity.additionalData?.fromTokenValue ?? '', activity.additionalData?.fromToken ?? '');
     const title = activity.type ? activity?.type.charAt(0).toUpperCase() + activity.type.slice(1) : 'Unknown';
     return (
       <CyDView className="border-x border-sepratorColor">
-        {shouldRenderDate && <CyDView className={clsx(' border-sepratorColor bg-privacyMessageBackgroundColor p-[5px] justify-center')}>
+        {shouldRenderDate && <CyDView className={clsx(' border-sepratorColor p-[5px] justify-center')}>
           <CyDText className='font-bold text-[14px]'>{formatedDay}</CyDText>
         </CyDView>}
         <CyDTouchView className={clsx('flex flex-row items-center py-[10px] border-b-[0.5px] border-sepratorColor px-[10px]', { 'rounded-t-[24px] border-t-[0.5px]': shouldRenderDate, 'rounded-b-[24px]': (nextTransactionFormatedDay !== formatedDay) })}
@@ -336,7 +336,7 @@ const TxnScene = ({
                 <CyDText className='font-extrabold text-[14px]'>{title}</CyDText>
               </CyDView>
               <CyDView className='flex flex-row w-full justify-start items-center'>
-                <CyDFastImage className='h-[20px] w-[20px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
+                <CyDFastImage className='h-[18px] w-[18px] mr-[5px] rounded-full' resizeMode='contain' source={chainImg} />
                 <RenderTransactionItemDetails type={activity.type} from={activity.from} to={activity.to} />
               </CyDView>
             </CyDView>


### PR DESCRIPTION
Changing the selected chain in the portfolio now filters the transactions tab as well. The tab is also restyled to make it similar to the tokens tab.
Demo:
![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-09-22 at 12 22 40](https://github.com/CypherD-IO/mobile-app/assets/132334547/7eb5bec2-6698-4237-8665-5c60f7ce1f18)
