### PR TITLE
fix: :bug: temp fix for refreshing on seed phrase change

### DIFF
--- a/src/reducers/hdwallet_reducer.tsx
+++ b/src/reducers/hdwallet_reducer.tsx
@@ -14,20 +14,20 @@ export interface WalletKey {
 export class ChainWallet {
   public currentIndex: number;
   public wallets: WalletKey[];
-  constructor ({ currentIndex, wallets }: { currentIndex: number, wallets: WalletKey[]}) {
+  constructor({ currentIndex, wallets }: { currentIndex: number, wallets: WalletKey[] }) {
     this.currentIndex = currentIndex;
     this.wallets = wallets;
   }
 
-  public get address (): string | undefined {
+  public get address(): string | undefined {
     return (this.currentIndex < 0 || this.currentIndex > (this.wallets.length - 1)) ? undefined : this.wallets[this.currentIndex].address;
   }
 
-  public get privateKey (): Buffer | Uint8Array | string {
+  public get privateKey(): Buffer | Uint8Array | string {
     return (this.currentIndex < 0 || this.currentIndex > (this.wallets.length - 1)) ? 'null' : this.wallets[this.currentIndex].privateKey;
   }
 
-  public get publicKey (): Buffer | Uint8Array | string {
+  public get publicKey(): Buffer | Uint8Array | string {
     return (this.currentIndex < 0 || this.currentIndex > (this.wallets.length - 1)) ? 'null' : this.wallets[this.currentIndex].publicKey;
   }
 }
@@ -78,7 +78,7 @@ export const initialHdWalletState: HDWallet = {
 };
 
 // reducers
-export function hdWalletStateReducer (state: any, action: any) {
+export function hdWalletStateReducer(state: any, action: any) {
   switch (action.type) {
     case 'ADD_ADDRESS': {
       const { address, privateKey, chain, publicKey } = action.value;
@@ -189,31 +189,38 @@ export function hdWalletStateReducer (state: any, action: any) {
       return { ...state, ...action.value };
     }
 
-    case 'RESET_WALLET' : {
+    case 'RESET_WALLET': {
       const resetWallet = initialHdWalletState;
       resetWallet.pinValue = state.pinValue;
-      resetWallet.wallet = wallet;
+      const emptyWallet: CypherDWallet = {};
+      CHAIN_NAMES.forEach(chain => {
+        emptyWallet[chain] = new ChainWallet({
+          currentIndex: -1,
+          wallets: []
+        });
+      });
+      resetWallet.wallet = emptyWallet;
       return { ...resetWallet };
     }
 
-    case 'RESET_PIN_AUTHENTICATION' : {
+    case 'RESET_PIN_AUTHENTICATION': {
       const { isReset } = action.value;
       let reset = state.reset;
       reset = isReset;
       return { ...state, reset };
     }
 
-    case 'SET_PIN_VALUE' : {
+    case 'SET_PIN_VALUE': {
       const { pin } = action.value;
       let pinValue = state.pinValue;
       pinValue = pin;
       return { ...state, pinValue };
     }
 
-    case 'TOGGLE_BALANCE_VISIBILITY' : {
+    case 'TOGGLE_BALANCE_VISIBILITY': {
       return { ...state, ...action.value };
     }
-    case 'SET_READ_ONLY_WALLET' : {
+    case 'SET_READ_ONLY_WALLET': {
       return { ...state, ...action.value };
     }
     default:


### PR DESCRIPTION
When resetting a wallet, the new empty wallet is now constructed in method and set to a fresh wallet. This is only a temp. fix.