### PR TITLE
fix: :ambulance: temp fix for verify-message calling returning 400

### DIFF
--- a/src/containers/Portfolio/index.tsx
+++ b/src/containers/Portfolio/index.tsx
@@ -114,7 +114,7 @@ export default function Portfolio({ navigation }: PortfolioProps) {
   const { scrollY, index, setIndex, bannerHeight, setBannerHeight, getRefForKey, ...sceneProps } =
     useScrollManager(tabsWithScrollableType);
 
-  const TOKEN = globalStateContext?.globalState.token;
+  const jwtToken = globalStateContext?.globalState.token;
   const ethereum = hdWallet?.state.wallet.ethereum;
 
   const handleBackButton = () => {
@@ -696,7 +696,7 @@ export default function Portfolio({ navigation }: PortfolioProps) {
         bannerHeight={bannerHeight}>
         <Banner bannerHeight={bannerHeight} checkAllBalance={checkAll(portfolioState)} />
         {
-          TOKEN !== undefined ?
+          jwtToken !== undefined ?
             <BannerCarousel setBannerHeight={setBannerHeight} />
             : null
         }

--- a/src/containers/Portfolio/index.tsx
+++ b/src/containers/Portfolio/index.tsx
@@ -114,6 +114,7 @@ export default function Portfolio({ navigation }: PortfolioProps) {
   const { scrollY, index, setIndex, bannerHeight, setBannerHeight, getRefForKey, ...sceneProps } =
     useScrollManager(tabsWithScrollableType);
 
+  const TOKEN = globalStateContext?.globalState.token;
   const ethereum = hdWallet?.state.wallet.ethereum;
 
   const handleBackButton = () => {
@@ -694,7 +695,11 @@ export default function Portfolio({ navigation }: PortfolioProps) {
         scrollY={scrollY}
         bannerHeight={bannerHeight}>
         <Banner bannerHeight={bannerHeight} checkAllBalance={checkAll(portfolioState)} />
-        <BannerCarousel setBannerHeight={setBannerHeight} />
+        {
+          TOKEN !== undefined ?
+            <BannerCarousel setBannerHeight={setBannerHeight} />
+            : null
+        }
       </AnimatedBanner>
 
       <CyDView className={clsx('flex-1 pb-[40px]', { 'pb-[75px]': !isIOS() })}>


### PR DESCRIPTION
A new banner call happens before the token becomes available, in which the empty bearer token causes an error. So now, only after the token is not undefined, will the BannerCarousel be rendered.