### PR TITLE
style: :sparkles: increase the height of the banners in Portfolio

### DIFF
--- a/src/containers/Portfolio/animatedComponents/AnimatedBanner.tsx
+++ b/src/containers/Portfolio/animatedComponents/AnimatedBanner.tsx
@@ -9,9 +9,10 @@ import {
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { isIOS } from '../../../misc/checkers';
+import { PortfolioBannerHeights } from '../../../hooks/useScrollManager';
 export interface AnimatedBannerProps {
   scrollY: SharedValue<number>;
-  bannerHeight: 160 | 300,
+  bannerHeight: PortfolioBannerHeights,
   children: ReactNode;
 }
 

--- a/src/containers/Portfolio/animatedComponents/AnimatedBanner.tsx
+++ b/src/containers/Portfolio/animatedComponents/AnimatedBanner.tsx
@@ -11,7 +11,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { isIOS } from '../../../misc/checkers';
 export interface AnimatedBannerProps {
   scrollY: SharedValue<number>;
-  bannerHeight: 160 | 260,
+  bannerHeight: 160 | 300,
   children: ReactNode;
 }
 
@@ -43,8 +43,8 @@ export const AnimatedBanner = ({
   });
   return (
     <CyDAnimatedView
-      className={`absolute h-[${bannerHeight}px] z-10 px-[10px] w-full`}
-      style={[animatedStyles, { top: topInset }]}
+      className={`absolute z-10 w-full`}
+      style={[animatedStyles, { height: bannerHeight, top: topInset }]}
       {...otherProps}
     >
       {children}

--- a/src/containers/Portfolio/animatedComponents/AnimatedTabBar.tsx
+++ b/src/containers/Portfolio/animatedComponents/AnimatedTabBar.tsx
@@ -7,10 +7,11 @@ import {
 } from 'react-native-reanimated';
 import { CyDAnimatedView } from '../../../styles/tailwindStyles';
 import { isIOS } from '../../../misc/checkers';
+import { PortfolioBannerHeights } from '../../../hooks/useScrollManager';
 
 export interface AnimatedTabBarProps {
   scrollY: SharedValue<number>;
-  bannerHeight: 160 | 300;
+  bannerHeight: PortfolioBannerHeights;
   children: JSX.Element;
 }
 

--- a/src/containers/Portfolio/animatedComponents/AnimatedTabBar.tsx
+++ b/src/containers/Portfolio/animatedComponents/AnimatedTabBar.tsx
@@ -10,7 +10,7 @@ import { isIOS } from '../../../misc/checkers';
 
 export interface AnimatedTabBarProps {
   scrollY: SharedValue<number>;
-  bannerHeight: 160 | 260;
+  bannerHeight: 160 | 300;
   children: JSX.Element;
 }
 

--- a/src/containers/Portfolio/animatedComponents/AnimatedTabView.tsx
+++ b/src/containers/Portfolio/animatedComponents/AnimatedTabView.tsx
@@ -25,7 +25,7 @@ export interface AnimatedTabViewProps
     | 'windowSize'
     | 'ListEmptyComponent'
   > {
-  bannerHeight: 160 | 260;
+  bannerHeight: 160 | 300;
   data?: any[];
   renderItem?:
   | ListRenderItem<any>

--- a/src/containers/Portfolio/animatedComponents/AnimatedTabView.tsx
+++ b/src/containers/Portfolio/animatedComponents/AnimatedTabView.tsx
@@ -10,6 +10,7 @@ import Animated, {
   useAnimatedScrollHandler,
 } from 'react-native-reanimated';
 import { H_GUTTER } from '../constants';
+import { PortfolioBannerHeights } from '../../../hooks/useScrollManager';
 
 export interface AnimatedTabViewProps
   extends Pick<
@@ -25,7 +26,7 @@ export interface AnimatedTabViewProps
     | 'windowSize'
     | 'ListEmptyComponent'
   > {
-  bannerHeight: 160 | 300;
+  bannerHeight: PortfolioBannerHeights;
   data?: any[];
   renderItem?:
   | ListRenderItem<any>

--- a/src/containers/Portfolio/components/Banner.tsx
+++ b/src/containers/Portfolio/components/Banner.tsx
@@ -17,7 +17,7 @@ import clsx from 'clsx';
 import { StyleSheet } from 'react-native';
 
 interface BannerProps {
-  bannerHeight: 160 | 260
+  bannerHeight: 160 | 300
   checkAllBalance: number | string;
 }
 
@@ -38,61 +38,63 @@ export const Banner = ({ bannerHeight, checkAllBalance }: BannerProps) => {
     });
   };
   return (
-    <CyDImageBackground
-      className={
-        'w-full border mt-[4px] pt-[46px] rounded-[24px] border-sepratorColor overflow-hidden'
-      }
-      source={AppImages.PORTFOLIO_BG_S3}
-      resizeMode='cover'
-      imageStyle={styles.imageBGStyle}
-    >
-      <CyDView
-        className={clsx('mx-[14px] justify-center items-start', { 'h-[50%]': bannerHeight === 260 })}
+    <CyDView className={clsx('px-[10px]', { 'h-[55%]': bannerHeight === 300 })}>
+      <CyDImageBackground
+        className={
+          'w-full border mt-[4px] pt-[46px] rounded-[24px] border-sepratorColor overflow-hidden'
+        }
+        source={AppImages.PORTFOLIO_BG_S3}
+        resizeMode='cover'
+        imageStyle={styles.imageBGStyle}
       >
-        {getCurrentChainHoldings(
-          portfolioState.statePortfolio.tokenPortfolio,
-          portfolioState.statePortfolio.selectedChain
-        ) && (
-            <CyDView className='h-full'>
-              <CyDView>
-                <CyDText>{t('TOTAL_BALANCE')}</CyDText>
-                <CyDView className='flex flex-row items-center py-[3px]'>
-                  <CyDTokenValue className='text-[32px] font-extrabold text-primaryTextColor'>
-                    {checkAllBalance}
-                  </CyDTokenValue>
-                  <CyDTouchView
-                    onPress={() => {
-                      void hideBalances();
-                    }}
-                    className={clsx(
-                      'h-[32px] flex flex-row items-center pl-[10px] gap-[5px]'
-                    )}
-                  >
-                    <CyDFastImage
-                      source={
-                        hideBalance
-                          ? AppImages.CYPHER_HIDE
-                          : AppImages.CYPHER_SHOW
-                      }
-                      className='h-[16px] w-[16px] ml-[15px]'
-                      resizeMode='contain'
-                    />
-                    <CyDText className='text-[12px]'>
-                      {hideBalance ? t('SHOW') : t('HIDE')}
-                    </CyDText>
-                  </CyDTouchView>
+        <CyDView
+          className='mx-[14px] justify-center items-start'
+        >
+          {getCurrentChainHoldings(
+            portfolioState.statePortfolio.tokenPortfolio,
+            portfolioState.statePortfolio.selectedChain
+          ) && (
+              <CyDView className='h-full'>
+                <CyDView>
+                  <CyDText>{t('TOTAL_BALANCE')}</CyDText>
+                  <CyDView className='flex flex-row items-center py-[3px]'>
+                    <CyDTokenValue className='text-[32px] font-extrabold text-primaryTextColor'>
+                      {checkAllBalance}
+                    </CyDTokenValue>
+                    <CyDTouchView
+                      onPress={() => {
+                        void hideBalances();
+                      }}
+                      className={clsx(
+                        'h-[32px] flex flex-row items-center pl-[10px] gap-[5px]'
+                      )}
+                    >
+                      <CyDFastImage
+                        source={
+                          hideBalance
+                            ? AppImages.CYPHER_HIDE
+                            : AppImages.CYPHER_SHOW
+                        }
+                        className='h-[16px] w-[16px] ml-[15px]'
+                        resizeMode='contain'
+                      />
+                      <CyDText className='text-[12px]'>
+                        {hideBalance ? t('SHOW') : t('HIDE')}
+                      </CyDText>
+                    </CyDTouchView>
+                  </CyDView>
+                </CyDView>
+                <CyDView className={clsx('flex flex-row justify-center items-center bg-privacyMessageBackgroundColor rounded-[8px] px-[10px] py-[5px] my-[5px]',
+                  { 'opacity-0': !hideBalance })}>
+                  <CyDText className='text-[12px]'>
+                    {t('ALL_BALANCES_HIDDEN')}
+                  </CyDText>
                 </CyDView>
               </CyDView>
-              <CyDView className={clsx('flex flex-row justify-center items-center bg-privacyMessageBackgroundColor rounded-[8px] px-[10px] py-[5px] my-[5px]',
-                { 'opacity-0': !hideBalance })}>
-                <CyDText className='text-[12px]'>
-                  {t('ALL_BALANCES_HIDDEN')}
-                </CyDText>
-              </CyDView>
-            </CyDView>
-          )}
-      </CyDView>
-    </CyDImageBackground>
+            )}
+        </CyDView>
+      </CyDImageBackground>
+    </CyDView>
   );
 };
 

--- a/src/containers/Portfolio/components/Banner.tsx
+++ b/src/containers/Portfolio/components/Banner.tsx
@@ -15,9 +15,10 @@ import CyDTokenValue from '../../../components/v2/tokenValue';
 import AppImages from '../../../../assets/images/appImages';
 import clsx from 'clsx';
 import { StyleSheet } from 'react-native';
+import { PortfolioBannerHeights } from '../../../hooks/useScrollManager';
 
 interface BannerProps {
-  bannerHeight: 160 | 300
+  bannerHeight: PortfolioBannerHeights
   checkAllBalance: number | string;
 }
 

--- a/src/containers/Portfolio/components/BannerCarousel/BannerCarouselItem.tsx
+++ b/src/containers/Portfolio/components/BannerCarousel/BannerCarouselItem.tsx
@@ -35,7 +35,7 @@ const BannerCarouselItem = ({ item, index, boxWidth, halfBoxDistance, panX, setD
                 index * boxWidth - halfBoxDistance,
                 (index + 1) * boxWidth - halfBoxDistance, // adjust positioning
             ],
-            [0.85, 1, 0.85], // scale down when out of scope
+            [0.88, 1, 0.88], // scale down when out of scope
             Extrapolation.CLAMP,
         );
         return {

--- a/src/containers/Portfolio/components/BannerCarousel/index.tsx
+++ b/src/containers/Portfolio/components/BannerCarousel/index.tsx
@@ -32,7 +32,7 @@ const ARCH_HOST = hostWorker.getHost('ARCH_HOST');
 
 export type BridgeOrCardActivity = ExchangeTransaction | DebitCardTransaction;
 interface BannerCarouselProps {
-  setBannerHeight: React.Dispatch<React.SetStateAction<160 | 260>>;
+  setBannerHeight: React.Dispatch<React.SetStateAction<160 | 300>>;
 }
 
 const BannerCarousel = ({ setBannerHeight }: BannerCarouselProps) => {
@@ -118,7 +118,7 @@ const BannerCarousel = ({ setBannerHeight }: BannerCarouselProps) => {
   // useEffect to update the height of the banner when the no. of cards change.
   useEffect(() => {
     if (activityCards.length + staticCards.length) {
-      setBannerHeight(260);
+      setBannerHeight(300);
     } else {
       setBannerHeight(160);
     }
@@ -348,7 +348,7 @@ const BannerCarousel = ({ setBannerHeight }: BannerCarouselProps) => {
   return (
     <CardCarousel
       cardsData={cards}
-      moreThanOneCardOffset={1.175}
+      moreThanOneCardOffset={1.1}
       renderItem={renderItem}
     />
   );

--- a/src/containers/Portfolio/components/BannerCarousel/index.tsx
+++ b/src/containers/Portfolio/components/BannerCarousel/index.tsx
@@ -27,12 +27,13 @@ import { ACTIVITIES_REFRESH_TIMEOUT } from '../../../../constants/timeOuts';
 import { CyDView } from '../../../../styles/tailwindStyles';
 import CardCarousel from '../../../../components/v2/CardCarousel';
 import { SharedValue } from 'react-native-reanimated';
+import { PortfolioBannerHeights } from '../../../../hooks/useScrollManager';
 
 const ARCH_HOST = hostWorker.getHost('ARCH_HOST');
 
 export type BridgeOrCardActivity = ExchangeTransaction | DebitCardTransaction;
 interface BannerCarouselProps {
-  setBannerHeight: React.Dispatch<React.SetStateAction<160 | 300>>;
+  setBannerHeight: React.Dispatch<React.SetStateAction<PortfolioBannerHeights>>;
 }
 
 const BannerCarousel = ({ setBannerHeight }: BannerCarouselProps) => {

--- a/src/containers/Portfolio/components/HeaderBar.tsx
+++ b/src/containers/Portfolio/components/HeaderBar.tsx
@@ -11,7 +11,7 @@ import { isIOS } from '../../../misc/checkers';
 interface HeaderBarProps {
   navigation: any
   setChooseChain: Function
-  bannerHeight: 160 | 260
+  bannerHeight: 160 | 300
   scrollY: SharedValue<number>
   onWCSuccess: (e: BarCodeReadEvent) => void
   renderTitleComponent?: ReactNode

--- a/src/containers/Portfolio/components/HeaderBar.tsx
+++ b/src/containers/Portfolio/components/HeaderBar.tsx
@@ -7,11 +7,12 @@ import { screenTitle } from '../../../constants';
 import { BarCodeReadEvent } from 'react-native-camera';
 import { SharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { isIOS } from '../../../misc/checkers';
+import { PortfolioBannerHeights } from '../../../hooks/useScrollManager';
 
 interface HeaderBarProps {
   navigation: any
   setChooseChain: Function
-  bannerHeight: 160 | 300
+  bannerHeight: PortfolioBannerHeights
   scrollY: SharedValue<number>
   onWCSuccess: (e: BarCodeReadEvent) => void
   renderTitleComponent?: ReactNode

--- a/src/containers/Portfolio/scenes/nftScene.tsx
+++ b/src/containers/Portfolio/scenes/nftScene.tsx
@@ -27,6 +27,7 @@ import { Chain } from '../../../constants/server';
 import { intercomAnalyticsLog } from '../../utilities/analyticsUtility';
 import { ALL_CHAINS_TYPE } from '../../../constants/type';
 import { isIOS } from '../../../misc/checkers';
+import { PortfolioBannerHeights } from '../../../hooks/useScrollManager';
 
 type ScrollEvent = NativeSyntheticEvent<NativeScrollEvent>;
 
@@ -43,7 +44,7 @@ interface NFTSceneProps {
     setOptions: ({ title }: { title: string }) => void
     navigate: (screen: string, params?: {}) => void
   }
-  bannerHeight: 160 | 300;
+  bannerHeight: PortfolioBannerHeights;
 }
 
 const NFTScene = ({

--- a/src/containers/Portfolio/scenes/nftScene.tsx
+++ b/src/containers/Portfolio/scenes/nftScene.tsx
@@ -43,7 +43,7 @@ interface NFTSceneProps {
     setOptions: ({ title }: { title: string }) => void
     navigate: (screen: string, params?: {}) => void
   }
-  bannerHeight: 160 | 260;
+  bannerHeight: 160 | 300;
 }
 
 const NFTScene = ({

--- a/src/containers/Portfolio/scenes/tokenScene.tsx
+++ b/src/containers/Portfolio/scenes/tokenScene.tsx
@@ -54,7 +54,7 @@ interface TokenSceneProps {
   onMomentumScrollEnd: (e: ScrollEvent) => void;
   onScrollEndDrag: (e: ScrollEvent) => void;
   navigation: any;
-  bannerHeight: 160 | 260;
+  bannerHeight: 160 | 300;
   isVerifyCoinChecked: boolean;
   getAllChainBalance: (portfolioState: {
     statePortfolio: {

--- a/src/containers/Portfolio/scenes/tokenScene.tsx
+++ b/src/containers/Portfolio/scenes/tokenScene.tsx
@@ -43,6 +43,7 @@ import { CHAIN_COLLECTION, Chain } from '../../../constants/server';
 import { TokenMeta } from '../../../models/tokenMetaData.model';
 import { get, isEmpty, isEqual, sortBy } from 'lodash';
 import Loading from '../../../components/v2/loading';
+import { PortfolioBannerHeights } from '../../../hooks/useScrollManager';
 
 type ScrollEvent = NativeSyntheticEvent<NativeScrollEvent>;
 
@@ -54,7 +55,7 @@ interface TokenSceneProps {
   onMomentumScrollEnd: (e: ScrollEvent) => void;
   onScrollEndDrag: (e: ScrollEvent) => void;
   navigation: any;
-  bannerHeight: 160 | 300;
+  bannerHeight: PortfolioBannerHeights;
   isVerifyCoinChecked: boolean;
   getAllChainBalance: (portfolioState: {
     statePortfolio: {

--- a/src/containers/Portfolio/scenes/txnScene.tsx
+++ b/src/containers/Portfolio/scenes/txnScene.tsx
@@ -19,6 +19,7 @@ import { TransactionObj } from "../../../models/transaction.model";
 import { CHAIN_COLLECTION, ChainConfigMapping } from "../../../constants/server";
 import clsx from "clsx";
 import { isIOS } from "../../../misc/checkers";
+import { PortfolioBannerHeights } from "../../../hooks/useScrollManager";
 
 interface TxnItemProps {
   activity: TransactionObj
@@ -35,7 +36,7 @@ interface TxnSceneProps {
   onMomentumScrollEnd: (e: ScrollEvent) => void;
   onScrollEndDrag: (e: ScrollEvent) => void;
   navigation: any;
-  bannerHeight: 160 | 300;
+  bannerHeight: PortfolioBannerHeights;
   filterModalVisibilityState: [boolean, React.Dispatch<React.SetStateAction<boolean>>]
 }
 

--- a/src/containers/Portfolio/scenes/txnScene.tsx
+++ b/src/containers/Portfolio/scenes/txnScene.tsx
@@ -35,7 +35,7 @@ interface TxnSceneProps {
   onMomentumScrollEnd: (e: ScrollEvent) => void;
   onScrollEndDrag: (e: ScrollEvent) => void;
   navigation: any;
-  bannerHeight: 160 | 260;
+  bannerHeight: 160 | 300;
   filterModalVisibilityState: [boolean, React.Dispatch<React.SetStateAction<boolean>>]
 }
 

--- a/src/hooks/useScrollManager/index.ts
+++ b/src/hooks/useScrollManager/index.ts
@@ -11,7 +11,7 @@ import { isIOS } from '../../misc/checkers';
 export const useScrollManager = (
   routes: Array<{ key: string; title: string; scrollableType: ScrollableType }>
 ) => {
-  const [bannerHeight, setBannerHeight] = useState<160 | 260>(160);
+  const [bannerHeight, setBannerHeight] = useState<160 | 300>(160);
   const OFFSET_TABVIEW = isIOS() ? -bannerHeight : 0;
   const scrollY = useSharedValue(-bannerHeight);
   const [index, setIndex] = useState(0);

--- a/src/hooks/useScrollManager/index.ts
+++ b/src/hooks/useScrollManager/index.ts
@@ -8,10 +8,12 @@ import {
 import { ScrollableType } from '../../constants/enum';
 import { isIOS } from '../../misc/checkers';
 
+export type PortfolioBannerHeights = 160 | 300
+
 export const useScrollManager = (
   routes: Array<{ key: string; title: string; scrollableType: ScrollableType }>
 ) => {
-  const [bannerHeight, setBannerHeight] = useState<160 | 300>(160);
+  const [bannerHeight, setBannerHeight] = useState<PortfolioBannerHeights>(160);
   const OFFSET_TABVIEW = isIOS() ? -bannerHeight : 0;
   const scrollY = useSharedValue(-bannerHeight);
   const [index, setIndex] = useState(0);


### PR DESCRIPTION
Instead of beight 260px, the whole banner section now takes 300px and 55% of it occupied by the Balance Banner and 45% of it is occupied by the Banner Card Carousel.