### PR TITLE
CYP-1622-status-updates-in-banner-for-all-statuses

### DIFF
--- a/src/containers/Portfolio/components/BannerCarousel/index.tsx
+++ b/src/containers/Portfolio/components/BannerCarousel/index.tsx
@@ -191,15 +191,13 @@ const BannerCarousel = ({ setBannerHeight }: BannerCarouselProps) => {
         if (quoteId === activityQuoteId) {
           const updatedStatus = _getUpdatedActivityStatus(status);
           if (currentActivityStatus !== updatedStatus) {
-            if (updatedStatus === ActivityStatus.SUCCESS) {
-              activityContext?.dispatch({
-                type: ActivityReducerAction.PATCH,
-                value: {
-                  id: activity.id,
-                  status: updatedStatus,
-                },
-              });
-            }
+            activityContext?.dispatch({
+              type: ActivityReducerAction.PATCH,
+              value: {
+                id: activity.id,
+                status: updatedStatus,
+              },
+            });
           }
           const returnActivity = activity;
           returnActivity.status = updatedStatus;


### PR DESCRIPTION
The Activity context only dispatched a PATCH action if the updated status was success. Now it will for any status different from the previous status.