### PR TITLE
CYP-1629-remove-timezone-offset-for-card-transactions-call

### DIFF
--- a/src/containers/DebitCard/CardV2/index.tsx
+++ b/src/containers/DebitCard/CardV2/index.tsx
@@ -123,7 +123,7 @@ const CypherCardScreen = ({ navigation, route }: CypherCardScreenProps) => {
         let txnURL = `/v1/cards/${currentCardProvider}/card/${String(currentCard?.cardId)}/transactions`;
         if (filter.dateRange !== initialCardTxnDateRange) {
             const { fromDate, toDate } = filter.dateRange;
-            txnURL += `?startDate=${moment(fromDate).startOf('day').toISOString()}&endDate=${moment(toDate).endOf('day').toISOString()}`;
+            txnURL += `?startDate=${moment.utc(fromDate).startOf('day').toISOString()}&endDate=${moment.utc(toDate).endOf('day').toISOString()}`;
         }
         try {
             setRefreshing(true);


### PR DESCRIPTION
Changed moment() to moment.utc() for removing the timezone diff.