### PR TITLE
chore: :art: config eslint, prettier and workspace settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     'react-native/no-inline-styles': 2,
     'react-native/no-color-literals': 'off',
     'react-native/no-raw-text': 2,
+    'react-hooks/exhaustive-deps': 'off',
     'react-native/no-single-element-style-arrays': 2,
     '@typescript-eslint/strict-boolean-expressions': 'off',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,8 +29,6 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
-    semi: ['error', 'always'],
-    '@typescript-eslint/semi': 'off',
     'react-native/no-unused-styles': 2,
     'react-native/split-platform-components': 2,
     'react-native/no-inline-styles': 2,
@@ -38,7 +36,5 @@ module.exports = {
     'react-native/no-raw-text': 2,
     'react-native/no-single-element-style-arrays': 2,
     '@typescript-eslint/strict-boolean-expressions': 'off',
-    'prettier/prettier': 0,
-    'react/jsx-key': 0,
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,6 @@ ios/sentry.properties
 DEVELOPER_GUIDE.md
 
 #vscode settings
-/.vscode/
 .env
 
 #android

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,7 +6,7 @@
   "bracketSameLine": true,
   "singleQuote": true,
   "jsxSingleQuote": true,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "semi": true,
   "endOfLine": "lf",
   "overrides": [

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,13 @@
 {
+  "printWidth": 80,
   "tabWidth": 2,
   "useTabs": false,
   "arrowParens": "avoid",
   "bracketSameLine": true,
   "singleQuote": true,
   "jsxSingleQuote": true,
-  "trailingComma": "all",
+  "trailingComma": "es5",
+  "semi": true,
   "endOfLine": "lf",
   "overrides": [
     {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,18 @@
 {
   "tabWidth": 2,
   "useTabs": false,
+  "arrowParens": "avoid",
+  "bracketSameLine": true,
   "singleQuote": true,
-  "jsxSingleQuote": true
+  "jsxSingleQuote": true,
+  "trailingComma": "all",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": ["*.js", "*.js.flow"],
+      "options": {
+        "parser": "hermes"
+      }
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}


### PR DESCRIPTION
Configured the eslintrc and prettierrc files to have the necessary rules. Removed .vscode from gitignore to have workspace settings in remote. Include formatting settings in the workspace settings.

breaks the current format of code across the repo.

The user must have Prettier VSCode extension installed.