### PR TITLE
fix: :bug: token across chains params changes

### DIFF
--- a/src/containers/Portfolio/scenes/tokenScene.tsx
+++ b/src/containers/Portfolio/scenes/tokenScene.tsx
@@ -260,9 +260,7 @@ const TokenScene = ({
               otherChainsWithToken: get(
                 tokensGroupedByCoinGeckoId,
                 item.split(':')[0],
-              )
-                .filter(otherChain => otherChain !== item)
-                .map(otherChain => get(holdingsData, otherChain)),
+              ).map(otherChain => get(holdingsData, otherChain)),
               viewableItems,
             })
           }

--- a/src/containers/TokenOverview/overview.tsx
+++ b/src/containers/TokenOverview/overview.tsx
@@ -45,7 +45,6 @@ import {
 import AppImages from '../../../assets/images/appImages';
 import FastImage from 'react-native-fast-image';
 import { Colors } from '../../constants/theme';
-import { REFRESH_CLOSING_TIMEOUT } from '../../constants/timeOuts';
 import HTML from 'react-native-render-html';
 import { screenTitle } from '../../constants';
 import Animated, {
@@ -607,7 +606,9 @@ export default function Overview({
           <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
-            data={otherChainsWithToken}
+            data={otherChainsWithToken.filter(
+              otherChainItem => otherChainItem !== tokenData,
+            )}
             renderItem={({ item }) => {
               const tokenVal = `${
                 +item.totalValue +


### PR DESCRIPTION
Sending the whole otherChainsWithToken to the overview page. Filtering out the current chain when passing to the flatlist.

now the otherChainsWithToken show only Tokens in other chains. This is true even after navigating to the other chain thru this feature.