### PR TITLE
fix: :bug: include june in card txn date range

### DIFF
--- a/src/constants/cardPageV2.ts
+++ b/src/constants/cardPageV2.ts
@@ -17,7 +17,7 @@ export interface DateRange {
   toDate: Date;
 }
 export const initialCardTxnDateRange = {
-  fromDate: new Date(2023, 6, 1), // inital date in June 1st, 2023 when the card was launched
+  fromDate: new Date('June 01, 2023 00:00:00'), // inital date in June 1st, 2023 when the card was launched
   toDate: new Date(),
 };
 

--- a/src/containers/DebitCard/CardV2/CardTxnFilterModal.tsx
+++ b/src/containers/DebitCard/CardV2/CardTxnFilterModal.tsx
@@ -178,7 +178,7 @@ const CardTxnFilterModal = ({
             )}
             {index === 1 && (
               <DateRangeFilterPicker
-                minimumDate={new Date(2023, 6, 1)}
+                minimumDate={new Date('June 01, 2023 00:00:00')}
                 maximumDate={new Date()}
                 dateRangeState={[selectedDateRange, setSelectedDateRange]}
               />


### PR DESCRIPTION
changed the date object to include june in the filtered txns and in the date range filter minimum date

This fixes some transactions in June being excluded due to the incorrect date handling.