### PR TITLE
CYP-1765-card-txn-date-range-filter-android-hotfix

### DIFF
--- a/src/constants/cardPageV2.ts
+++ b/src/constants/cardPageV2.ts
@@ -17,7 +17,7 @@ export interface DateRange {
   toDate: Date;
 }
 export const initialCardTxnDateRange = {
-  fromDate: new Date('June 01, 2023 00:00:00'), // inital date in June 1st, 2023 when the card was launched
+  fromDate: new Date(2023, 5, 1), // inital date in June 1st, 2023 when the card was launched
   toDate: new Date(),
 };
 

--- a/src/containers/DebitCard/CardV2/CardTxnFilterModal.tsx
+++ b/src/containers/DebitCard/CardV2/CardTxnFilterModal.tsx
@@ -178,7 +178,7 @@ const CardTxnFilterModal = ({
             )}
             {index === 1 && (
               <DateRangeFilterPicker
-                minimumDate={new Date('June 01, 2023 00:00:00')}
+                minimumDate={new Date(2023, 5, 1)}
                 maximumDate={new Date()}
                 dateRangeState={[selectedDateRange, setSelectedDateRange]}
               />


### PR DESCRIPTION
Used the Date object constructor that works in both android and iOS.

This fixes the issue where the date filter didn't work in Android causing invalid dates.