### PR TITLE
use dReason id cDReason is not available

### DIFF
--- a/src/containers/DebitCard/bridgeCard/transactionDetails.tsx
+++ b/src/containers/DebitCard/bridgeCard/transactionDetails.tsx
@@ -130,7 +130,7 @@ const TransactionDetail = ({
   item,
   isSettled,
   isDeclined = false,
-  cDReason = '',
+  reason = '',
 }: {
   item: {
     icon: any;
@@ -142,7 +142,7 @@ const TransactionDetail = ({
   };
   isSettled: boolean;
   isDeclined?: boolean;
-  cDReason?: string;
+  reason?: string;
 }) => {
   return (
     <CyDView className='pb-[5px] rounded-[7px] mt-[25px] bg-lightGrey'>
@@ -159,6 +159,8 @@ const TransactionDetail = ({
           // Check to remove default as a item value.
           if (!(detailItem.value === 'default')) {
             return <DetailItem item={detailItem} key={index} />;
+          } else {
+            return null;
           }
         })}
         {!isSettled && item.title === t('TRANSACTION_DETAILS') && (
@@ -167,8 +169,7 @@ const TransactionDetail = ({
               <CyDText className='font-bold underline'>
                 {isDeclined ? 'Reason:' : 'Note:'}
               </CyDText>
-              {' ' +
-                (isDeclined ? cDReason : t('TRANSACTION_YET_TO_BE_SETTLED'))}
+              {' ' + (isDeclined ? reason : t('TRANSACTION_YET_TO_BE_SETTLED'))}
             </CyDText>
           </CyDView>
         )}
@@ -347,9 +348,9 @@ export default function TransactionDetails() {
               <TransactionDetail
                 item={item}
                 key={index}
-                isSettled={transaction.isSettled}
+                isSettled={transaction?.isSettled ?? false}
                 isDeclined={transaction.tStatus === ReapTxnStatus.DECLINED}
-                cDReason={transaction.cDReason}
+                reason={transaction?.cDReason ?? transaction?.dReason ?? ''}
               />
             );
           }

--- a/src/containers/DebitCard/bridgeCard/transactionDetails.tsx
+++ b/src/containers/DebitCard/bridgeCard/transactionDetails.tsx
@@ -33,7 +33,6 @@ import { GlobalContext, GlobalContextDef } from '../../../core/globalContext';
 import { ICardTransaction } from '../../../models/card.model';
 import { capitalize, split } from 'lodash';
 import { t } from 'i18next';
-import useCardUtilities from '../../../hooks/useCardUtilities';
 import { CardProfile } from '../../../models/cardProfile.model';
 import Toast from 'react-native-toast-message';
 
@@ -259,7 +258,7 @@ export default function TransactionDetails() {
               t('CONVERSION_RATE') +
               '\n' +
               `(USD to ${String(fxCurrencySymbol)})`,
-            value: formatAmount(fxConversionPrice),
+            value: formatAmount(fxConversionPrice ?? 0),
           },
           {
             label: t('TRANSACTION_AMOUNT'),
@@ -350,9 +349,11 @@ export default function TransactionDetails() {
                 key={index}
                 isSettled={transaction?.isSettled ?? false}
                 isDeclined={transaction.tStatus === ReapTxnStatus.DECLINED}
-                reason={transaction?.cDReason ?? transaction?.dReason ?? ''}
+                reason={transaction?.dReason ?? transaction?.cDReason ?? ''}
               />
             );
+          } else {
+            return null;
           }
         })}
         {!transaction.isSettled &&

--- a/src/models/card.model.ts
+++ b/src/models/card.model.ts
@@ -69,6 +69,7 @@ export interface ICardTransaction {
   label?: string;
   isSettled?: boolean;
   cDReason?: string;
+  dReason?: string;
   tStatus?: ReapTxnStatus;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `TransactionDetail` component to simplify the naming of the reason for declined transactions.
	- Introduced a fallback mechanism for the reason prop to enhance user experience.
	- Added a new optional property to capture additional transaction-related information.

- **Bug Fixes**
	- Improved handling of undefined values for `isSettled` to ensure robustness in transaction details display.

- **Refactor**
	- Renamed `cDReason` to `reason` for clarity and consistency in the component's props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->