### PR TITLE
fix(ci/cd): use info.plsit for versioning iOS

### DIFF
--- a/ios/Cypherd/Info.plist
+++ b/ios/Cypherd/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.86.0</string>
+	<string>2.89.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application version for "Cypher Wallet" to 2.89.0.
- **Improvements**
	- Enhanced script for Node.js installation to dynamically read version from `.nvmrc` or default to 18.17.1.
	- Added user feedback for Node.js version during installation.
	- Streamlined the script by removing unnecessary version management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->