### PR TITLE
fix solana fisrtload on max

### DIFF
--- a/ios/Cypherd/Info.plist
+++ b/ios/Cypherd/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.00.0</string>
+	<string>2.99.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/Cypherd/Info.plist
+++ b/ios/Cypherd/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.99.0</string>
+	<string>3.00.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/src/containers/DebitCard/CardV2/firstLoadCard.tsx
+++ b/src/containers/DebitCard/CardV2/firstLoadCard.tsx
@@ -535,7 +535,7 @@ export default function FirstLoadCard() {
           amount: DecimalHelper.toNumber(amountInCrypto),
           coinId: coinGeckoId,
           amountInCrypto: true,
-          tokenAddress: denom,
+          tokenAddress: contractAddress,
         };
         const response = await postWithAuth(
           `/v1/cards/${currentCardProvider}/card/${cardId}/quote`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 3.00.0.
  
- **Bug Fixes**
  - Corrected the token address used during the card funding process for the Solana network, ensuring more accurate transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->