### PR TITLE
fix: load fee shown wrong in quote data

### DIFF
--- a/src/containers/DebitCard/bridgeCard/quote.tsx
+++ b/src/containers/DebitCard/bridgeCard/quote.tsx
@@ -541,7 +541,7 @@ export default function CardQuote({
           <CyDView
             className={'flex flex-col flex-wrap justify-between items-end'}>
             <CyDText className={'font-medium text-[14px] '}>
-              {'$' + String(tokenQuote.fees.actualFee)}
+              {'$' + String(tokenQuote.fees.fee)}
             </CyDText>
           </CyDView>
         </CyDView>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the fee display in card quotes to ensure the correct fee information is shown during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->