### PR TITLE
fix: portfolio called when ethereum address is undefined in hdwallet

### DIFF
--- a/src/hooks/usePortfolio/index.ts
+++ b/src/hooks/usePortfolio/index.ts
@@ -36,7 +36,7 @@ export default function usePortfolio() {
       kujira,
       solana,
     } = hdWallet.state.wallet;
-    if (ethereum.address !== 'null') {
+    if (ethereum.address && ethereum.address !== 'null') {
       const addresses = [
         ethereum.address,
         cosmos?.wallets[cosmos?.currentIndex]?.address,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved portfolio retrieval by enhancing validation checks, ensuring stability when wallet addresses are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->