### PR TITLE
fix: show rc conset only for US

### DIFF
--- a/src/containers/DebitCard/CardV2/signup/application/billingAddress.tsx
+++ b/src/containers/DebitCard/CardV2/signup/application/billingAddress.tsx
@@ -290,7 +290,7 @@ export default function BillingAddress({
               onPress={() => setAcceptTerms(!acceptTerms)}>
               <CyDView
                 className={clsx(
-                  'h-[20px] w-[20px] border-[1px] rounded-[4px]',
+                  'h-[20px] w-[20px] border-[1px] rounded-[4px] border-base100',
                   {
                     'bg-p150 border-p150': acceptTerms,
                   },
@@ -321,14 +321,14 @@ export default function BillingAddress({
             </CyDText>
           </CyDView>
 
-          {!isRainCard && (
+          {!isRainCard && values.country === 'US' && (
             <CyDView className='flex flex-row w-full'>
               <CyDTouchView
                 className='flex flex-row items-center p-[8px] -m-[8px]'
                 onPress={() => setAcceptConsent(!acceptConsent)}>
                 <CyDView
                   className={clsx(
-                    'h-[20px] w-[20px] border-[1px] rounded-[4px]',
+                    'h-[20px] w-[20px] border-[1px] rounded-[4px] border-base100',
                     {
                       'bg-p150 border-p150': acceptConsent,
                     },

--- a/src/containers/DebitCard/CardV2/signup/application/index.tsx
+++ b/src/containers/DebitCard/CardV2/signup/application/index.tsx
@@ -395,7 +395,9 @@ export default function CardApplicationV2() {
                   loaderStyle={styles.loading}
                   loading={isSubmitting}
                   disabled={
-                    (!isRainCard && (!acceptTerms || !acceptConsent)) ||
+                    (!isRainCard &&
+                      values.country === 'US' &&
+                      (!acceptTerms || !acceptConsent)) ||
                     !acceptTerms
                   }
                 />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced visual styling by updating border visuals for key form elements.

- **New Features**
  - Revised consent display to appear only for eligible US users.
  - Adjusted the continue button’s enablement logic based on user location and card type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->