### PR TITLE
fix: fx fee info in plan info

### DIFF
--- a/src/components/selectPlanModal.tsx
+++ b/src/components/selectPlanModal.tsx
@@ -663,7 +663,10 @@ export default function SelectPlanModal({
                   {t('COMPARISION_NOTE_3')}
                 </CyDText>
                 <CyDText className='text-n200 text-[12px] font-normal mt-[10px]'>
-                  {t('COMPARISION_NOTE_4')}
+                  {t('COMPARISION_NOTE_4', {
+                    forexMarkupStandard: freePlanData?.fxMarkup,
+                    forexMarkupPremium: proPlanData?.fxMarkup,
+                  })}
                 </CyDText>
               </CyDTouchView>
             </CyDScrollView>

--- a/src/components/selectPlanModal.tsx
+++ b/src/components/selectPlanModal.tsx
@@ -662,6 +662,9 @@ export default function SelectPlanModal({
                 <CyDText className='text-n200 text-[12px] font-normal mt-[10px]'>
                   {t('COMPARISION_NOTE_3')}
                 </CyDText>
+                <CyDText className='text-n200 text-[12px] font-normal mt-[10px]'>
+                  {t('COMPARISION_NOTE_4')}
+                </CyDText>
               </CyDTouchView>
             </CyDScrollView>
           </CyDView>

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1152,7 +1152,7 @@ const resources = {
       COMPARISION_NOTE_3:
         '(3) Lower liquidity tokens may incur crypto load fees of up to 3%.',
       COMPARISION_NOTE_4:
-        '(4) Cypher charges a 1% forex markup for standard users and 0% for premium users. However, other financial institutions involved in processsing the transaction may charge extra fees of 0.25% to 1%, which are not controlled by Cypher.',
+        '(4) Cypher charges a {{forexMarkupStandard}}% forex markup for standard users and {{forexMarkupPremium}}% for premium users. However, other financial institutions involved in processsing the transaction may charge extra fees of 0.25% to 1%, which are not controlled by Cypher.',
       GET_YOUR_CARD: 'Get your Card',
       GET_YOUR_CARD_SUB: 'Here is  what you need to do next',
       ENTER_BASIC_DETAILS: 'Enter your Basic Details',

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1152,7 +1152,7 @@ const resources = {
       COMPARISION_NOTE_3:
         '(3) Lower liquidity tokens may incur crypto load fees of up to 3%.',
       COMPARISION_NOTE_4:
-        '(4) Cypher charges a 1% forex markup fee for standard users and 0% for premium users. However, please note that your bank may apply an additional fee ranging from 0.25% to 1%, which is not controlled or charged by Cypher.',
+        '(4) Cypher charges a 1% forex markup for standard users and 0% for premium users. However, other financial institutions involved in processsing the transaction may charge extra fees of 0.25% to 1%, which are not controlled by Cypher.',
       GET_YOUR_CARD: 'Get your Card',
       GET_YOUR_CARD_SUB: 'Here is  what you need to do next',
       ENTER_BASIC_DETAILS: 'Enter your Basic Details',

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1135,7 +1135,7 @@ const resources = {
       ORDER_YOUR_METAL_CARD: 'Order your Metal Card',
       USDC_TOKEN: 'USDC token',
       OTHER_TOKENS: 'Other tokens',
-      FOREX_MARKUP_NON_USD: 'Forex Markup (Non USD)',
+      FOREX_MARKUP_NON_USD: 'Forex Markup (Non USD)*',
       CRYPTO_LOAD_FEE: 'Crypto load fee',
       CHARGE_BACK_COVER: 'Chargeback Cover',
       ATM_FEE: 'ATM Withdraw Fee',
@@ -1151,6 +1151,8 @@ const resources = {
       COMPARISION_NOTE_2: '(2) Shipping Charges Apply for add on cards',
       COMPARISION_NOTE_3:
         '(3) Lower liquidity tokens may incur crypto load fees of up to 3%.',
+      COMPARISION_NOTE_4:
+        '(4) Cypher charges a 1% forex markup fee for standard users and 0% for premium users. However, please note that your bank may apply an additional fee ranging from 0.25% to 1%, which is not controlled or charged by Cypher.',
       GET_YOUR_CARD: 'Get your Card',
       GET_YOUR_CARD_SUB: 'Here is  what you need to do next',
       ENTER_BASIC_DETAILS: 'Enter your Basic Details',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an additional informational note to the plan comparison modal, providing more details about forex markup fees.

- **Documentation**
  - Updated and expanded translation resources to include the new informational note and clarified forex markup fee details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->