### PR TITLE
fix: overcharged info shown in transactions

### DIFF
--- a/src/components/v2/CardTransactionItem.tsx
+++ b/src/components/v2/CardTransactionItem.tsx
@@ -173,37 +173,35 @@ const CardTransactionItem = ({ item }: CardTransactionItemProps) => {
                 </CyDText>
               </CyDView>
             ) : (
-              <CyDText
-                className={clsx('font-[600] text-[14px] mr-[5px]', {
-                  'text-successTextGreen':
-                    type === CardTransactionTypes.CREDIT ||
-                    type === CardTransactionTypes.REFUND,
-                })}>
-                {getTransactionSign(type)}
-                {getSymbolFromCurrency(fxCurrencySymbol ?? 'USD') ??
-                  fxCurrencySymbol}{' '}
-                {limitDecimalPlaces(fxCurrencyValue ?? amount, 2)}{' '}
-              </CyDText>
+              <>
+                <CyDView className='flex flex-row items-center mb-[2px]'>
+                  <CyDText
+                    className={clsx('font-[600] text-[14px] mr-[5px]', {
+                      'text-successTextGreen':
+                        type === CardTransactionTypes.CREDIT ||
+                        type === CardTransactionTypes.REFUND,
+                    })}>
+                    {getTransactionSign(type)}
+                    {getSymbolFromCurrency(fxCurrencySymbol ?? 'USD') ??
+                      fxCurrencySymbol}{' '}
+                    {limitDecimalPlaces(fxCurrencyValue ?? amount, 2)}{' '}
+                  </CyDText>
+                </CyDView>
+                {isPotentiallyDccOvercharged(item) && (
+                  <CyDView className='flex flex-row items-center w-fit rounded-full bg-red20 px-[4px] py-[2px]'>
+                    <CyDMaterialDesignIcons
+                      name='alert-circle'
+                      size={12}
+                      className='text-red400 mr-[2px]'
+                    />
+                    <CyDText className='text-[10px] font-semibold text-red400'>
+                      {t('OVERCHARGED')}
+                    </CyDText>
+                  </CyDView>
+                )}
+              </>
             )}
           </CyDView>
-        </CyDView>
-        <CyDView className='flex flex-row justify-between items-center w-full'>
-          {item.metadata?.merchant?.merchantCountry &&
-            isPotentiallyDccOvercharged(item) && (
-              <CyDView className='bg-p10 rounded-full flex flex-row items-center px-[12px] py-[6px] mt-[8px] w-full'>
-                <CyDMaterialDesignIcons
-                  name='exclamation'
-                  size={14}
-                  className='text-red400 mr-[2px]'
-                />
-                <CyDText className='font-bold text-[12px] mr-[2px]'>
-                  {t('ATTENTION')}:
-                </CyDText>
-                <CyDText className='text-[12px] flex-1 flex-wrap'>
-                  {t('OVERCHARGED_BY_MERCHANT')}
-                </CyDText>
-              </CyDView>
-            )}
         </CyDView>
       </CyDTouchView>
     </>

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1687,6 +1687,7 @@ const resources = {
       OVERCHARGED_BY_MERCHANT_TEXT: 'Overcharged by Merchant',
       HIGH_FOREX_FEE_INFO_TEXT_1:
         'High forex markup fee of 5% - 15% charged by the merchant. To avoid such high charges, always choose the local currency at the card terminal or during ATM withdrawals.',
+      OVERCHARGED: 'Overcharged',
     },
   },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible badge below transaction amounts to indicate potential DCC (Dynamic Currency Conversion) overcharges, featuring a red alert icon and "OVERCHARGED" label.
- **Style**
  - Updated transaction amount layout for improved clarity and emphasis.
- **Documentation**
  - Added a new translation for the "Overcharged" label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->