### PR TITLE
version bump

### DIFF
--- a/ios/Cypherd/Info.plist
+++ b/ios/Cypherd/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.09.5</string>
+	<string>3.09.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the app version number to 3.09.6 on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->