### PR TITLE
Implement PIN Lock Grace Period and Fix OTP Resend Timer Issues

### DIFF
--- a/src/containers/Portfolio/index.tsx
+++ b/src/containers/Portfolio/index.tsx
@@ -115,9 +115,7 @@ export default function Portfolio({ navigation }: PortfolioProps) {
   const [chooseChain, setChooseChain] = useState<boolean>(false);
   const [isVerifyCoinChecked, setIsVerifyCoinChecked] = useState<boolean>(true);
   const [appState, setAppState] = useState<string>('');
-  const [backgroundTimestamp, setBackgroundTimestamp] = useState<number | null>(
-    null,
-  );
+  const backgroundTimestampRef = useRef<number | null>(null);
   const [filterModalVisible, setFilterModalVisible] = useState(false);
   const { showModal, hideModal } = useGlobalModalContext();
 
@@ -177,29 +175,29 @@ export default function Portfolio({ navigation }: PortfolioProps) {
         if (hdWallet?.state.pinValue) {
           if (changeType === 'background') {
             // Store timestamp when app goes to background
-            setBackgroundTimestamp(Date.now());
+            backgroundTimestampRef.current = Date.now();
           } else if (changeType === 'active') {
             // Check grace period when app becomes active
             const now = Date.now();
             const gracePeriodMs = 2 * 60 * 1000; // 2 minutes in milliseconds
 
             if (
-              backgroundTimestamp &&
-              now - backgroundTimestamp < gracePeriodMs
+              backgroundTimestampRef.current &&
+              now - backgroundTimestampRef.current < gracePeriodMs
             ) {
               // Within grace period, don't show pin screen
-              setBackgroundTimestamp(null);
+              backgroundTimestampRef.current = null;
               return;
             }
 
             // Grace period expired or no background timestamp, show pin screen
-            setBackgroundTimestamp(null);
+            backgroundTimestampRef.current = null;
           }
           setAppState(() => changeType);
         }
       }
     },
-    [hdWallet?.state.pinValue, backgroundTimestamp],
+    [hdWallet?.state.pinValue],
   );
 
   useEffect(() => {


### PR DESCRIPTION
This PR introduces a 2-minute grace period for the app PIN lock, ensuring users are not immediately prompted for a PIN when briefly switching apps. The logic now tracks when the app enters the background and only triggers the PIN screen if the app remains inactive beyond the grace period.
Additionally, this update resolves issues with OTP handling:
 • A new OTP is now properly triggered on input focus.
 • The resend timer no longer gets stuck, with improved interval and cleanup logic.
Other minor code cleanups and refactoring are included for better maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a grace period when returning to the app, so the PIN lock screen will not appear if the app was briefly backgrounded (less than 2 minutes).

- **Bug Fixes**
  - Improved timer handling for OTP resending to ensure countdowns and resets work more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->