### PR TITLE
Fix: WalletConnect V2 Signing Modal Not Displaying & Event Handling Improvements

### DIFF
--- a/src/components/v2/walletConnectV2Views/SigningModal.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModal.tsx
@@ -374,6 +374,7 @@ export default function SigningModal({
     if (payloadFrom === SigningModalPayloadFrom.WALLETCONNECT) {
       try {
         setAcceptingRequest(true);
+
         if (isMessageModalForSigningTypedData) {
           modalPayload?.resolve(true);
         } else {
@@ -382,12 +383,15 @@ export default function SigningModal({
             { title: '', host: '', origin: '', url: '' },
             chain,
           );
+
           const formattedRPCResponse = formatJsonRpcResult(id, response.result);
+
           await web3wallet?.respondSessionRequest({
             topic,
             response: formattedRPCResponse,
           });
         }
+
         setAcceptingRequest(false);
         hideModal();
       } catch (e) {
@@ -401,30 +405,33 @@ export default function SigningModal({
 
   async function handleReject() {
     if (payloadFrom === SigningModalPayloadFrom.WALLETCONNECT) {
-      const { id } = requestEvent;
-      if (id) {
+      const requestId = (requestEvent as any)?.id;
+      if (requestId) {
         try {
           setRejectingRequest(true);
+
           if (isMessageModalForSigningTypedData) {
             modalPayload?.resolve(false);
           } else {
             const rejectionResponse = formatJsonRpcError(
-              id,
+              requestId,
               getSdkError('USER_REJECTED_METHODS').message,
             );
+
             await web3wallet?.respondSessionRequest({
               topic,
               response: rejectionResponse,
             });
           }
+
           setRejectingRequest(false);
-          (hideModal as () => void)(); // Type asserting that hideModal cannot be undefined here.
+          hideModal();
         } catch (e) {
           setRejectingRequest(false);
-          (hideModal as () => void)(); // Type asserting that hideModal cannot be undefined here.
+          hideModal();
         }
       } else {
-        (hideModal as () => void)(); // Type asserting that hideModal cannot be undefined here.
+        hideModal();
       }
     } else {
       modalPayload?.resolve(false);

--- a/src/components/walletConnectV2Provider/index.tsx
+++ b/src/components/walletConnectV2Provider/index.tsx
@@ -29,23 +29,25 @@ export const WalletConnectV2Provider: React.FC<any> = ({ children }) => {
 
   const [isWeb3WalletInitialized, setIsWeb3WalletInitialized] =
     useState<boolean>(false);
+
   useWalletConnectEventsManager(isWeb3WalletInitialized);
 
   const onInitialize = useCallback(async () => {
-    // const resp = await getWithAuth('/v1/authentication/creds/wc'); //TO DO Eliminate sign message race condition (axios intercept)
-    // if (!resp.isError) {
-    //   const { data } = resp;
-    //   projectId = data.projectId;
-    // }
     try {
       if (projectId) {
         await createWeb3Wallet(projectId);
         setIsWeb3WalletInitialized(true);
+      } else {
+        console.error('[WalletConnectV2Provider] Missing projectId');
       }
     } catch (err: unknown) {
+      console.error(
+        '[WalletConnectV2Provider] Error during wallet initialization:',
+        err,
+      );
       Sentry.captureException(err);
     }
-  }, []);
+  }, [projectId]);
 
   useEffect(() => {
     if (
@@ -56,13 +58,13 @@ export const WalletConnectV2Provider: React.FC<any> = ({ children }) => {
       isInitializationInProgress.current = true;
       void onInitialize();
     }
-  }, [isWeb3WalletInitialized, ethereumAddress]);
+  }, [isWeb3WalletInitialized, ethereumAddress, onInitialize]);
 
   const { url: initialUrl } = useInitialIntentURL();
 
   const initiateWalletConnection = async () => {
     if (initialUrl) {
-      let uri = initialUrl?.url ?? initialUrl;
+      let uri = initialUrl;
       if (uri?.includes('cypherwallet://')) {
         uri = uri?.replace('cypherwallet://', '');
       }
@@ -89,10 +91,5 @@ export const WalletConnectV2Provider: React.FC<any> = ({ children }) => {
     }
   }, [initialUrl, isWeb3WalletInitialized, ethereum?.wallets]);
 
-  return (
-    // <WalletConnectContext.Provider
-    //   value={{ initialized: isWeb3WalletInitialized }}>
-    <WagmiConfigBuilder>{children}</WagmiConfigBuilder>
-    // </WalletConnectContext.Provider>
-  );
+  return <WagmiConfigBuilder>{children}</WagmiConfigBuilder>;
 };

--- a/src/core/walletConnectV2Utils.ts
+++ b/src/core/walletConnectV2Utils.ts
@@ -1,18 +1,16 @@
-/* eslint-disable no-useless-catch */
 import { Core } from '@walletconnect/core';
 import { getSdkError } from '@walletconnect/utils';
 import { WalletKit, IWalletKit } from '@reown/walletkit';
 import * as Sentry from '@sentry/react-native';
+
 export let web3wallet: IWalletKit;
 export let core: any;
 
 export async function createWeb3Wallet(projectId: string) {
   try {
     core = new Core({
-      // logger: 'debug',
       projectId,
-      relayUrl: 'wss://relay.walletconnect.com', // Note the .com instead of .org
-      // relayUrl: relayerRegionURL ?? process.env.NEXT_PUBLIC_RELAY_URL
+      relayUrl: 'wss://relay.walletconnect.com',
     });
 
     web3wallet = await WalletKit.init({
@@ -24,24 +22,43 @@ export async function createWeb3Wallet(projectId: string) {
         icons: ['https://public.cypherd.io/icons/appLogo.png'],
       },
     });
+
+    try {
+      const clientId =
+        await web3wallet.engine.signClient.core.crypto.getClientId();
+    } catch (error) {
+      console.error('Failed to set WalletConnect clientId in state', error);
+    }
+
     return web3wallet;
   } catch (e) {
+    console.error('[WalletConnectV2Utils] Error creating web3wallet:', e);
     Sentry.captureException(e);
+    throw e;
   }
 }
 
 export async function web3WalletPair({ uri }: { uri: string }) {
   try {
+    if (!web3wallet) {
+      throw new Error('web3wallet not initialized');
+    }
     const pairPromise = await web3wallet.core.pairing.pair({ uri });
     return pairPromise;
   } catch (e) {
+    console.error('[WalletConnectV2Utils] Error pairing:', e);
     throw e;
   }
 }
 
 export const deleteTopic = async (topic: string) => {
-  await web3wallet.disconnectSession({
-    topic,
-    reason: getSdkError('USER_DISCONNECTED'),
-  });
+  try {
+    await web3wallet.disconnectSession({
+      topic,
+      reason: getSdkError('USER_DISCONNECTED'),
+    });
+  } catch (e) {
+    console.error('[WalletConnectV2Utils] Error disconnecting session:', e);
+    throw e;
+  }
 };

--- a/src/hooks/useWalletConnectV2EventsManager/index.ts
+++ b/src/hooks/useWalletConnectV2EventsManager/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { SignClientTypes } from '@walletconnect/types';
-import { useCallback, useContext, useEffect } from 'react';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 import { deleteTopic, web3wallet } from '../../core/walletConnectV2Utils';
 import {
   COSMOS_SIGNING_METHODS,
@@ -18,83 +18,165 @@ import { t } from 'i18next';
 
 export default function useWalletConnectEventsManager(initialized: boolean) {
   const hdWalletContext = useContext<any>(HdWalletContext);
-  const { walletConnectDispatch } = useContext<any>(WalletConnectContext);
-  const ethereum = hdWalletContext.state.wallet.ethereum;
-  const { showModal, hideModal } = useGlobalModalContext();
+  const walletConnectContextValue = useContext<any>(WalletConnectContext);
+  const globalModalContext = useGlobalModalContext();
+  const listenersRegistered = useRef<boolean>(false);
+
+  // Ensure we have all required context values
+  const ethereum = hdWalletContext?.state?.wallet?.ethereum;
+  const walletConnectDispatch =
+    walletConnectContextValue?.walletConnectDispatch;
+  const { showModal, hideModal } = globalModalContext || {};
+
   const onSessionProposal = useCallback(
-    (proposal: SignClientTypes.EventArguments['session_proposal']) => {
+    (proposal: any) => {
+      if (!showModal || !ethereum?.wallets?.[ethereum?.currentIndex]?.address) {
+        console.error(
+          '[WalletConnect] Missing dependencies for session proposal',
+        );
+        return;
+      }
+
       showModal(GlobalModalType.WALLET_CONNECT_V2_PAIRING, {
         currentProposal: proposal,
         hideModal,
         currentETHAddress: ethereum.wallets[ethereum.currentIndex].address,
       });
     },
-    [ethereum],
+    [showModal, hideModal, ethereum],
   );
 
   const onSessionRequest = useCallback(
-    async (requestEvent: SignClientTypes.EventArguments['session_request']) => {
+    async (requestEvent: any) => {
+      if (!showModal || !hideModal) {
+        console.error(
+          '[WalletConnect] Missing modal context for session request',
+        );
+        return;
+      }
+
       const { params } = requestEvent;
       const { request } = params;
 
-      switch (request.method) {
-        case EIP155_SIGNING_METHODS.ETH_SIGN:
-        case EIP155_SIGNING_METHODS.PERSONAL_SIGN:
-        case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA:
-        case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3:
-        case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4:
-        case EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION:
-        case EIP155_SIGNING_METHODS.ETH_SIGN_TRANSACTION:
-          return showModal(GlobalModalType.WALLET_CONNECT_V2_SIGNING, {
-            requestEvent,
-            hideModal,
-            currentETHAddress: ethereum.wallets[ethereum.currentIndex].address,
-          });
+      try {
+        switch (request.method) {
+          case EIP155_SIGNING_METHODS.ETH_SIGN:
+          case EIP155_SIGNING_METHODS.PERSONAL_SIGN:
+          case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA:
+          case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3:
+          case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4:
+          case EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION:
+          case EIP155_SIGNING_METHODS.ETH_SIGN_TRANSACTION: {
+            const currentETHAddress =
+              ethereum?.wallets?.[ethereum?.currentIndex]?.address;
+            if (!currentETHAddress) {
+              console.error(
+                '[WalletConnect] No ETH address available for signing',
+              );
+              return;
+            }
 
-        case COSMOS_SIGNING_METHODS.COSMOS_SIGN_DIRECT:
-        case COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO:
-          return showModal(GlobalModalType.WALLET_CONNECT_V2_COSMOS_SIGNING, {
-            requestEvent,
-            hideModal,
-          });
-        default:
-          return showModal('state', {
-            type: 'error',
-            title: t('UNSUPPORTED_METHOD'),
-            description: t('UNSUPPORTED_METHOD_DESCRIPTION'),
-            onSuccess: hideModal,
-            onFailure: hideModal,
-          });
+            return showModal(GlobalModalType.WALLET_CONNECT_V2_SIGNING, {
+              requestEvent,
+              hideModal,
+              currentETHAddress,
+            });
+          }
+
+          case COSMOS_SIGNING_METHODS.COSMOS_SIGN_DIRECT:
+          case COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO:
+            return showModal(GlobalModalType.WALLET_CONNECT_V2_COSMOS_SIGNING, {
+              requestEvent,
+              hideModal,
+            });
+          default:
+            return showModal('state', {
+              type: 'error',
+              title: t('UNSUPPORTED_METHOD'),
+              description: t('UNSUPPORTED_METHOD_DESCRIPTION'),
+              onSuccess: hideModal,
+              onFailure: hideModal,
+            });
+        }
+      } catch (error) {
+        console.error('[WalletConnect] Error handling session request:', error);
+        Sentry.captureException(error);
+        return showModal('state', {
+          type: 'error',
+          title: 'WalletConnect Error',
+          description: 'Failed to process signing request. Please try again.',
+          onSuccess: hideModal,
+          onFailure: hideModal,
+        });
       }
     },
-    [],
+    [showModal, hideModal, ethereum],
   );
 
-  const onSessionRemoval = useCallback(async ({ topic }) => {
-    walletConnectDispatch({
-      type: WalletConnectActions.REMOVE_WALLETCONNECT_2_CONNECTION,
-      value: { topic },
-    });
-  }, []);
+  const onSessionRemoval = useCallback(
+    async ({ topic }: any) => {
+      if (!walletConnectDispatch) {
+        console.error(
+          '[WalletConnect] Missing walletConnectDispatch for session removal',
+        );
+        return;
+      }
+
+      walletConnectDispatch({
+        type: WalletConnectActions.REMOVE_WALLETCONNECT_2_CONNECTION,
+        value: { topic },
+      });
+    },
+    [walletConnectDispatch],
+  );
 
   /******************************************************************************
    * Set up WalletConnect event listeners
    *****************************************************************************/
   useEffect(() => {
-    if (initialized) {
-      // sign
+    if (
+      initialized &&
+      web3wallet &&
+      !listenersRegistered.current &&
+      onSessionProposal &&
+      onSessionRequest &&
+      onSessionRemoval
+    ) {
       try {
-        web3wallet?.on('session_proposal', onSessionProposal);
-        web3wallet?.on('session_request', onSessionRequest);
-        web3wallet?.on('session_delete', onSessionRemoval);
+        // Register listeners
+        web3wallet.on('session_proposal', onSessionProposal);
+        web3wallet.on('session_request', onSessionRequest);
+        web3wallet.on('session_delete', onSessionRemoval);
+
+        listenersRegistered.current = true;
       } catch (e) {
+        console.error('[WalletConnect] Error registering event listeners:', e);
         Sentry.captureException(e);
       }
-      // TODOs
-      // signClient.on('session_ping', data => console.log('ping', data))
-      // signClient.on('session_event', data => console.log('event', data))
-      // signClient.on('session_update', data => console.log('update', data))
-      // signClient.on('session_delete', data => console.log('delete', data))
     }
+
+    // Cleanup function
+    return () => {
+      if (web3wallet && listenersRegistered.current) {
+        try {
+          web3wallet.off('session_proposal', onSessionProposal);
+          web3wallet.off('session_request', onSessionRequest);
+          web3wallet.off('session_delete', onSessionRemoval);
+          listenersRegistered.current = false;
+        } catch (e) {
+          console.error(
+            '[WalletConnect] Error cleaning up event listeners:',
+            e,
+          );
+        }
+      }
+    };
   }, [initialized, onSessionProposal, onSessionRequest, onSessionRemoval]);
+
+  // Additional effect to handle web3wallet changes
+  useEffect(() => {
+    if (!web3wallet && listenersRegistered.current) {
+      listenersRegistered.current = false;
+    }
+  }, [web3wallet]);
 }


### PR DESCRIPTION
This PR addresses issues with WalletConnect V2 message signing modals not appearing and introduces multiple improvements for connection reliability and error handling:
 • Fixes the bug where the WalletConnect signing modal would not pop up for sign message requests.
 • Refactors event listener registration for WalletConnect V2 to ensure listeners are only registered once, with proper cleanup and error logging.
 • Improves context and dependency checks throughout WalletConnect event flows, reducing the risk of undefined errors.
 • Updates the WalletConnect provider initialization logic for better error handling and clearer logging if ‎`projectId` is missing.
 • Adds defensive checks and clearer error messages in utility functions (‎`createWeb3Wallet`, ‎`web3WalletPair`, and ‎`deleteTopic`), improving debugging and reliability.
 • Cleans up modal and signing logic for more robust user experience on both approval and rejection of requests.
 • General code cleanup, improved comments, and more consistent use of hooks and dependencies.

These changes improve the stability and UX of WalletConnect V2 sessions, especially when interacting with dApps that require message signing or transaction approvals.