### PR TITLE
fix: refactor PinInput to eliminate clipboard auto-fill bug and enabl…

### DIFF
--- a/ios/Config.xcconfig
+++ b/ios/Config.xcconfig
@@ -1,3 +1,3 @@
 #include? "tmp.xcconfig"
 
-MARKETING_VERSION = 3.11.9
+MARKETING_VERSION = 3.11.10

--- a/src/components/v2/card/otpVerification.tsx
+++ b/src/components/v2/card/otpVerification.tsx
@@ -160,6 +160,7 @@ export default function OtpVerificationModal({
                 error={otpError}
                 onBlur={handleOtpBlur}
                 length={4}
+                isOtp
               />
               <CyDTouchView
                 className={'flex flex-row items-center mt-[15%]'}

--- a/src/components/v2/pinInput.tsx
+++ b/src/components/v2/pinInput.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx';
-import React, { useRef } from 'react';
-import { TextInput } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { StyleSheet, TextInput } from 'react-native';
 import {
   CyDText,
   CyDTextInput,
+  CyDTouchView,
   CyDView,
 } from '../../styles/tailwindComponents';
 
@@ -29,14 +30,36 @@ export const PinInput = ({
   const inputRef = useRef<TextInput>(null);
   const joined = value.join('');
 
+  useEffect(() => {
+    if (!isOtp) return;
+    const t = setTimeout(() => inputRef.current?.focus(), 300);
+    return () => clearTimeout(t);
+  }, [isOtp]);
+
   const handleChangeText = (text: string) => {
     const digits = text.replace(/\D/g, '').slice(0, length);
     const next = Array.from({ length }, (_, i) => digits[i] ?? '');
     onChange(next);
   };
 
+  const focusInput = () => inputRef.current?.focus();
+
   return (
     <CyDView className={className}>
+      <CyDTextInput
+        ref={inputRef as React.Ref<TextInput>}
+        style={styles.hiddenInput}
+        keyboardType='numeric'
+        maxLength={length}
+        value={joined}
+        onChangeText={handleChangeText}
+        onBlur={onBlur}
+        autoFocus={isOtp}
+        autoComplete={isOtp ? 'sms-otp' : 'off'}
+        textContentType={isOtp ? 'oneTimeCode' : 'none'}
+        importantForAutofill={isOtp ? 'yes' : 'no'}
+        caretHidden
+      />
       {Array.from({ length }, (_, index) => {
         const filled = !!value[index];
         const display = filled
@@ -44,35 +67,37 @@ export const PinInput = ({
             ? '•'
             : value[index]
           : '';
+        const isActive = joined.length === index;
         return (
-          <CyDView
+          <CyDTouchView
             key={index}
+            activeOpacity={0.8}
+            onPress={focusInput}
             className={clsx(
               'h-[64px] w-[50px] mx-[4px] rounded-[8px] border-[1px] bg-n0 items-center justify-center',
               {
                 'border-redCyD': error,
-                'border-base200': !error,
+                'border-base400': !error && isActive,
+                'border-base200': !error && !isActive,
               },
             )}>
             <CyDText className='text-[22px] font-bold font-manrope text-base400'>
               {display}
             </CyDText>
-          </CyDView>
+          </CyDTouchView>
         );
       })}
-      <CyDTextInput
-        ref={inputRef as React.Ref<TextInput>}
-        className='absolute top-0 left-0 right-0 bottom-0 opacity-0'
-        keyboardType='numeric'
-        maxLength={length}
-        value={joined}
-        onChangeText={handleChangeText}
-        onBlur={onBlur}
-        autoComplete={isOtp ? 'sms-otp' : 'off'}
-        textContentType={isOtp ? 'oneTimeCode' : 'none'}
-        importantForAutofill={isOtp ? 'yes' : 'no'}
-        caretHidden
-      />
     </CyDView>
   );
 };
+
+const styles = StyleSheet.create({
+  hiddenInput: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    opacity: 0,
+  },
+});

--- a/src/components/v2/pinInput.tsx
+++ b/src/components/v2/pinInput.tsx
@@ -1,7 +1,11 @@
 import clsx from 'clsx';
-import React, { useRef, useEffect } from 'react';
-import Clipboard from '@react-native-clipboard/clipboard';
-import { CyDView, CyDTextInput } from '../../styles/tailwindComponents';
+import React, { useRef } from 'react';
+import { TextInput } from 'react-native';
+import {
+  CyDText,
+  CyDTextInput,
+  CyDView,
+} from '../../styles/tailwindComponents';
 
 export const PinInput = ({
   value,
@@ -10,6 +14,7 @@ export const PinInput = ({
   onBlur,
   length,
   isSecureTextEntry = false,
+  isOtp = false,
   className = 'flex-row justify-center',
 }: {
   value: string[];
@@ -18,101 +23,56 @@ export const PinInput = ({
   onBlur: () => void;
   length: number;
   isSecureTextEntry?: boolean;
+  isOtp?: boolean;
   className?: string;
 }) => {
-  const inputRefs = useRef([]);
-  const keyPressedRef = useRef(false);
+  const inputRef = useRef<TextInput>(null);
+  const joined = value.join('');
 
-  useEffect(() => {
-    inputRefs.current = inputRefs.current.slice(0, length);
-  }, [length]);
-
-  const handleChangeText = async (
-    text: string,
-    index: number,
-  ): Promise<void> => {
-    if (keyPressedRef.current) {
-      keyPressedRef.current = false;
-      return;
-    }
-    keyPressedRef.current = false;
-
-    try {
-      const clipboardContent = await Clipboard.getString();
-      const digits = clipboardContent.trim().replace(/\D/g, '');
-      if (digits.length >= length) {
-        onChange(digits.slice(0, length).split(''));
-        inputRefs?.current[length - 1]?.focus();
-        return;
-      }
-    } catch {}
-    if (text.length === 1 && /^\d$/.test(text)) {
-      const newValue = [...value];
-      newValue[index] = text;
-      onChange(newValue);
-      if (index < length - 1) {
-        inputRefs?.current[index + 1]?.focus();
-      }
-    }
-  };
-
-  const handleKeyPress = (index: number, e: any): void => {
-    keyPressedRef.current = true;
-    const key = e.nativeEvent.key;
-
-    if (/^\d$/.test(key)) {
-      const newValue = [...value];
-
-      // If current box is not empty and not the last box, move to next box
-      if (newValue[index] !== '' && index < length - 1) {
-        newValue[index + 1] = key;
-        onChange(newValue);
-        inputRefs?.current[index + 1]?.focus();
-      } else {
-        newValue[index] = key;
-        onChange(newValue);
-        // Move to the next box if not the last one
-        if (index < length - 1) {
-          inputRefs?.current[index + 1]?.focus();
-        }
-      }
-    } else if (key === 'Backspace') {
-      const newValue = [...value];
-      newValue[index] = '';
-      onChange(newValue);
-
-      // Move to the previous box if not the first one
-      if (index > 0) {
-        inputRefs?.current[index - 1]?.focus();
-      }
-    }
+  const handleChangeText = (text: string) => {
+    const digits = text.replace(/\D/g, '').slice(0, length);
+    const next = Array.from({ length }, (_, i) => digits[i] ?? '');
+    onChange(next);
   };
 
   return (
     <CyDView className={className}>
-      {Array.from({ length }, (_, index) => (
-        <CyDTextInput
-          key={index}
-          ref={el => (inputRefs.current[index] = el)}
-          className={clsx(
-            'h-[64px] w-[50px] text-[22px] font-bold text-center rounded-[8px] border-[1px] border-base200 bg-n0 font-manrope text-base400',
-            'mx-[4px]',
-            {
-              'border-redCyD': error,
-            },
-          )}
-          keyboardType='numeric'
-          maxLength={1}
-          value={value[index] || ''}
-          onChangeText={text => {
-            void handleChangeText(text, index);
-          }}
-          onKeyPress={e => handleKeyPress(index, e)}
-          secureTextEntry={isSecureTextEntry}
-          onBlur={onBlur}
-          selectTextOnFocus
-        />
-      ))}
+      {Array.from({ length }, (_, index) => {
+        const filled = !!value[index];
+        const display = filled
+          ? isSecureTextEntry
+            ? '•'
+            : value[index]
+          : '';
+        return (
+          <CyDView
+            key={index}
+            className={clsx(
+              'h-[64px] w-[50px] mx-[4px] rounded-[8px] border-[1px] bg-n0 items-center justify-center',
+              {
+                'border-redCyD': error,
+                'border-base200': !error,
+              },
+            )}>
+            <CyDText className='text-[22px] font-bold font-manrope text-base400'>
+              {display}
+            </CyDText>
+          </CyDView>
+        );
+      })}
+      <CyDTextInput
+        ref={inputRef as React.Ref<TextInput>}
+        className='absolute top-0 left-0 right-0 bottom-0 opacity-0'
+        keyboardType='numeric'
+        maxLength={length}
+        value={joined}
+        onChangeText={handleChangeText}
+        onBlur={onBlur}
+        autoComplete={isOtp ? 'sms-otp' : 'off'}
+        textContentType={isOtp ? 'oneTimeCode' : 'none'}
+        importantForAutofill={isOtp ? 'yes' : 'no'}
+        caretHidden
+      />
     </CyDView>
   );
 };

--- a/src/containers/DebitCard/bridgeCard/cardRevealAuth.tsx
+++ b/src/containers/DebitCard/bridgeCard/cardRevealAuth.tsx
@@ -357,6 +357,7 @@ export default function CardRevealAuthScreen() {
             error={otpError}
             onBlur={handleOtpBlur}
             length={4}
+            isOtp
             className='flex-row justify-start'
           />
           <CyDTouchView

--- a/src/containers/DebitCard/bridgeCard/cardUnlockAuth.tsx
+++ b/src/containers/DebitCard/bridgeCard/cardUnlockAuth.tsx
@@ -223,6 +223,7 @@ export default function CardUnlockAuth() {
               error={otpError}
               onBlur={handleOtpBlur}
               length={4}
+              isOtp
             />
             <CyDTouchView
               className={'flex flex-row items-center mt-[8px]'}


### PR DESCRIPTION
…e SMS/email autofill

   Replace per-box TextInput architecture with single hidden input + visual boxes. This:
   - Removes clipboard read-on-every-keystroke that caused false auto-fill (the reported bug)
   - Enables proper system autofill on iOS (Messages SMS, Apple Mail with textContentType=oneTimeCode)
   - Enables Android SMS autofill (autoComplete=sms-otp)
   - Fixes long-press paste to correctly paste full code instead of clamping to 1 char
   - Removes clipboard privacy toast on Android 12+ that appeared for every keystroke

   Add isOtp prop (default false) to control autofill props. Enable for card reveal screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PIN input now supports native OTP autofill and optimized focus behavior for faster verification on supported devices.

* **Refactor**
  * PIN input UI and handling reworked for simpler, more reliable input (preserves secure entry, validation, and paste behavior).

* **Chore**
  * App marketing/version number advanced to 3.11.10.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CypherD-IO/mobile-app/pull/890)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->