### PR TITLE
fix: unify ethereum stablecoin

### DIFF
--- a/src/components/v2/InsufficientGasFeeDescription.tsx
+++ b/src/components/v2/InsufficientGasFeeDescription.tsx
@@ -37,7 +37,7 @@ const formatUsd = (
   return `~$${formatAmount(usd, 2)}`;
 };
 
-const InsufficientGasFeeDescription: React.FC<
+export const InsufficientGasFeeDescription: React.FC<
   InsufficientGasFeeDescriptionProps
 > = ({
   gasFeeInCrypto,
@@ -47,8 +47,12 @@ const InsufficientGasFeeDescription: React.FC<
 }) => {
   const { t } = useTranslation();
 
-  const requiredCrypto = `~${formatCryptoAmount(gasFeeInCrypto)} ${nativeTokenSymbol}`;
-  const availableCrypto = `${formatCryptoAmount(balanceInCrypto)} ${nativeTokenSymbol}`;
+  const requiredCrypto = `~${formatCryptoAmount(
+    gasFeeInCrypto,
+  )} ${nativeTokenSymbol}`;
+  const availableCrypto = `${formatCryptoAmount(
+    balanceInCrypto,
+  )} ${nativeTokenSymbol}`;
   const requiredUsd = formatUsd(gasFeeInCrypto, nativeTokenPrice);
   const availableUsd = formatUsd(balanceInCrypto, nativeTokenPrice);
 
@@ -107,5 +111,3 @@ const InsufficientGasFeeDescription: React.FC<
     </CyDView>
   );
 };
-
-export default InsufficientGasFeeDescription;

--- a/src/components/v2/InsufficientGasFeeDescription.tsx
+++ b/src/components/v2/InsufficientGasFeeDescription.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { formatAmount } from '../../core/util';
+import {
+  CyDMaterialDesignIcons,
+  CyDText,
+  CyDView,
+} from '../../styles/tailwindComponents';
+import { DecimalHelper } from '../../utils/decimalHelper';
+
+interface InsufficientGasFeeDescriptionProps {
+  gasFeeInCrypto: string;
+  balanceInCrypto: string;
+  nativeTokenSymbol: string;
+  nativeTokenPrice?: number | string;
+}
+
+const formatCryptoAmount = (value: string): string => {
+  const amount = DecimalHelper.fromString(value);
+  if (
+    DecimalHelper.isGreaterThan(amount, 0) &&
+    DecimalHelper.isLessThan(amount, 0.00001)
+  ) {
+    return '< 0.00001';
+  }
+  return formatAmount(value, 6);
+};
+
+const formatUsd = (
+  cryptoAmount: string,
+  price?: number | string,
+): string | null => {
+  if (price === undefined || price === null || price === '') return null;
+  const priceDecimal = DecimalHelper.fromString(price);
+  if (DecimalHelper.isLessThanOrEqualTo(priceDecimal, 0)) return null;
+  const usd = DecimalHelper.multiply(cryptoAmount, priceDecimal);
+  return `~$${formatAmount(usd, 2)}`;
+};
+
+const InsufficientGasFeeDescription: React.FC<
+  InsufficientGasFeeDescriptionProps
+> = ({
+  gasFeeInCrypto,
+  balanceInCrypto,
+  nativeTokenSymbol,
+  nativeTokenPrice,
+}) => {
+  const { t } = useTranslation();
+
+  const requiredCrypto = `~${formatCryptoAmount(gasFeeInCrypto)} ${nativeTokenSymbol}`;
+  const availableCrypto = `${formatCryptoAmount(balanceInCrypto)} ${nativeTokenSymbol}`;
+  const requiredUsd = formatUsd(gasFeeInCrypto, nativeTokenPrice);
+  const availableUsd = formatUsd(balanceInCrypto, nativeTokenPrice);
+
+  return (
+    <CyDView className='mt-[15px] mb-[10px]'>
+      <CyDText className='text-[14px] text-base400 text-center'>
+        {t('INSUFFICIENT_GAS_FEE_INTRO', { symbol: nativeTokenSymbol })}
+      </CyDText>
+
+      <CyDView className='mt-[16px] bg-n30 rounded-[12px] px-[16px] py-[14px]'>
+        <CyDView className='flex-row items-start justify-between'>
+          <CyDText className='text-[13px] text-base200'>
+            {t('INSUFFICIENT_GAS_FEE_REQUIRED')}
+          </CyDText>
+          <CyDView className='items-end'>
+            <CyDText className='text-[15px] font-bold text-base400'>
+              {requiredCrypto}
+            </CyDText>
+            {requiredUsd && (
+              <CyDText className='text-[12px] text-base200 mt-[2px]'>
+                {requiredUsd}
+              </CyDText>
+            )}
+          </CyDView>
+        </CyDView>
+
+        <CyDView className='h-[1px] bg-n40 my-[10px]' />
+
+        <CyDView className='flex-row items-start justify-between'>
+          <CyDText className='text-[13px] text-base200'>
+            {t('INSUFFICIENT_GAS_FEE_AVAILABLE')}
+          </CyDText>
+          <CyDView className='items-end'>
+            <CyDText className='text-[15px] font-bold text-base400'>
+              {availableCrypto}
+            </CyDText>
+            {availableUsd && (
+              <CyDText className='text-[12px] text-base200 mt-[2px]'>
+                {availableUsd}
+              </CyDText>
+            )}
+          </CyDView>
+        </CyDView>
+      </CyDView>
+
+      <CyDView className='mt-[14px] flex-row items-start'>
+        <CyDMaterialDesignIcons
+          name='information-outline'
+          size={14}
+          className='text-base150 mr-[6px] mt-[2px]'
+        />
+        <CyDText className='flex-1 text-[11px] italic text-base150 leading-[16px]'>
+          {t('INSUFFICIENT_GAS_FEE_ESTIMATE_NOTE')}
+        </CyDText>
+      </CyDView>
+    </CyDView>
+  );
+};
+
+export default InsufficientGasFeeDescription;

--- a/src/components/v2/chooseTokenModalV2.tsx
+++ b/src/components/v2/chooseTokenModalV2.tsx
@@ -44,7 +44,11 @@ import { Theme, useTheme } from '../../reducers/themeReducer';
 import { useColorScheme } from 'nativewind';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import useSupportedChains from '../../hooks/useSupportedChains/index';
-import { formatCurrencyWithSuffix, parseErrorMessage } from '../../core/util';
+import {
+  formatCurrencyWithSuffix,
+  getMinimumCardLoadAmount,
+  parseErrorMessage,
+} from '../../core/util';
 import Toast from 'react-native-toast-message';
 import CyDTokenValue from './tokenValue';
 
@@ -253,17 +257,8 @@ const RenderToken = React.memo(
   }) => {
     const { t } = useTranslation();
     const getMinimumTokenValue = (token: Holding | SupportedToken) => {
-      if (
-        type === TokenModalType.CARD_LOAD &&
-        token.chainDetails.chain_id === CHAIN_ETH.chain_id &&
-        !['usd-coin', 'tether'].includes(token.coinGeckoId)
-      ) {
-        return minTokenValueEth;
-      } else if (
-        type === TokenModalType.CARD_LOAD &&
-        token.accountType === 'spot'
-      ) {
-        return minTokenValueHlSpot;
+      if (type === TokenModalType.CARD_LOAD) {
+        return getMinimumCardLoadAmount(token as Holding);
       }
       return minTokenValueLimit;
     };

--- a/src/containers/Browser/Browser.tsx
+++ b/src/containers/Browser/Browser.tsx
@@ -27,6 +27,7 @@ import AppImages from '../../../assets/images/appImages';
 import ChooseChainModalV2 from '../../components/v2/chooseChainModal';
 import MoreViewModal from '../../components/MoreViewModal';
 import { useGlobalModalContext } from '../../components/v2/GlobalModal';
+import InsufficientGasFeeDescription from '../../components/v2/InsufficientGasFeeDescription';
 import Loading from '../../components/v2/loading';
 import { INJECTED_WEB3_CDN } from '../../constants/data';
 import { Web3Origin } from '../../constants/enum';
@@ -367,8 +368,15 @@ export default function Browser() {
         setTimeout(() => {
           showModal('state', {
             type: 'error',
-            title: t('INSUFFICIENT_FUNDS'),
-            description: `You don't have sufficient ${nativeToken.symbol} to pay gas fee`,
+            title: t('INSUFFICIENT_GAS_FEE'),
+            description: (
+              <InsufficientGasFeeDescription
+                gasFeeInCrypto={String(gasDetails.gasFeeInCrypto)}
+                balanceInCrypto={String(nativeToken.balanceDecimal)}
+                nativeTokenSymbol={nativeToken.symbol}
+                nativeTokenPrice={nativeToken.price}
+              />
+            ),
             onSuccess: hideModal,
             onFailure: hideModal,
           });

--- a/src/containers/DebitCard/bridgeCard/fundCard.tsx
+++ b/src/containers/DebitCard/bridgeCard/fundCard.tsx
@@ -14,6 +14,7 @@ import Button from '../../../components/v2/button';
 import ChooseTokenModalV2 from '../../../components/v2/chooseTokenModalV2';
 import { useGlobalBottomSheet } from '../../../components/v2/GlobalBottomSheetProvider';
 import { useGlobalModalContext } from '../../../components/v2/GlobalModal';
+import InsufficientGasFeeDescription from '../../../components/v2/InsufficientGasFeeDescription';
 import Loading from '../../../components/v2/loading';
 import CyDNumberPad from '../../../components/v2/numberpad';
 import CyDTokenAmount from '../../../components/v2/tokenAmount';
@@ -49,6 +50,7 @@ import useAxios from '../../../core/HttpRequest';
 import { Holding, IHyperLiquidHolding } from '../../../core/portfolio';
 import {
   formatAmount,
+  getMinimumCardLoadAmount,
   getViemPublicClient,
   getWeb3Endpoint,
   hasSufficientBalanceAndGasFee,
@@ -211,18 +213,7 @@ export default function BridgeFundCardScreen({
         // Filter tokens that are fundable and have value > minimum required
         const fundableTokens = localPortfolio.totalHoldings.filter(token => {
           if (!token.isFundable || !token.isVerified) return false;
-
-          // Check minimum value requirements based on chain and account type
-          const { backendName } = token.chainDetails;
-          let minimumValue = minTokenValueLimit;
-
-          if (backendName === CHAIN_ETH.backendName) {
-            minimumValue = minTokenValueEth;
-          } else if (token.accountType === 'spot') {
-            minimumValue = minTokenValueHlSpot;
-          }
-
-          return Number(token.totalValue) >= minimumValue;
+          return Number(token.totalValue) >= getMinimumCardLoadAmount(token);
         });
 
         // Sort by total value (descending) and select the first one
@@ -241,10 +232,7 @@ export default function BridgeFundCardScreen({
           setNativeTokenBalance(nativeToken?.balanceDecimal ?? '0');
 
           // Set suggested amounts
-          const tempMinTokenValue =
-            defaultToken.chainDetails.backendName === CHAIN_ETH.backendName
-              ? minTokenValueEth
-              : minTokenValueLimit;
+          const tempMinTokenValue = getMinimumCardLoadAmount(defaultToken);
           const splittableAmount = defaultToken.totalValue - tempMinTokenValue;
           if (splittableAmount >= tempMinTokenValue) {
             setSuggestedAmounts({
@@ -445,7 +433,16 @@ export default function BridgeFundCardScreen({
           showModal('state', {
             type: 'error',
             title: t('INSUFFICIENT_GAS_FEE'),
-            description: t('INSUFFICIENT_GAS_FEE_DESCRIPTION'),
+            description: (
+              <InsufficientGasFeeDescription
+                gasFeeInCrypto={String(gasDetails?.gasFeeInCrypto)}
+                balanceInCrypto={nativeTokenBalance}
+                nativeTokenSymbol={String(
+                  selectedToken?.chainDetails?.symbol ?? '',
+                )}
+                nativeTokenPrice={nativeToken?.price}
+              />
+            ),
             onSuccess: hideModal,
             onFailure: hideModal,
           });

--- a/src/containers/IBC/index.tsx
+++ b/src/containers/IBC/index.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../reducers/activity_reducer';
 import { genId } from '../utilities/activityUtilities';
 import { useGlobalModalContext } from '../../components/v2/GlobalModal';
+import InsufficientGasFeeDescription from '../../components/v2/InsufficientGasFeeDescription';
 import { MODAL_CLOSING_TIMEOUT } from '../../constants/timeOuts';
 import { SuccessTransaction } from '../../components/v2/StateModal';
 import CyDTokenAmount from '../../components/v2/tokenAmount';
@@ -236,8 +237,15 @@ export default function IBC({
           } else {
             await showModal('state', {
               type: 'error',
-              title: 'Insufficient balance for gas',
-              description: `You do not have enough balance in ${nativeToken?.name} to perform this action. Please load more ${nativeToken?.name} tokens in ${tokenData.chainDetails.name} chain to continue.`,
+              title: t('INSUFFICIENT_GAS_FEE'),
+              description: (
+                <InsufficientGasFeeDescription
+                  gasFeeInCrypto={String(gasDetails?.gasFeeInCrypto ?? '0')}
+                  balanceInCrypto={String(nativeToken?.balanceDecimal ?? '0')}
+                  nativeTokenSymbol={String(nativeToken?.symbol ?? '')}
+                  nativeTokenPrice={nativeToken?.price}
+                />
+              ),
               onSuccess: hideModal,
               onFailure: hideModal,
             });

--- a/src/containers/SendTo/enterAmount.tsx
+++ b/src/containers/SendTo/enterAmount.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { BackHandler, ActivityIndicator } from 'react-native';
 import Button from '../../components/v2/button';
 import { useGlobalModalContext } from '../../components/v2/GlobalModal';
+import InsufficientGasFeeDescription from '../../components/v2/InsufficientGasFeeDescription';
 import CyDTokenAmount from '../../components/v2/tokenAmount';
 import CyDTokenValue from '../../components/v2/tokenValue';
 import { ButtonType } from '../../constants/enum';
@@ -221,10 +222,20 @@ export default function EnterAmount(props: any) {
         onFailure: hideModal,
       });
     } else if (!(await haveEnoughNativeBalance(cryptoValue, gasReserved))) {
+      const nativeToken = await getNativeToken(
+        tokenData.chainDetails.backendName,
+      );
       showModal('state', {
         type: 'error',
-        title: t('INSUFFICIENT_FUNDS'),
-        description: `You don't have sufficient ${nativeTokenSymbol} to pay gas fee.`,
+        title: t('INSUFFICIENT_GAS_FEE'),
+        description: (
+          <InsufficientGasFeeDescription
+            gasFeeInCrypto={String(gasReserved)}
+            balanceInCrypto={String(nativeToken?.balanceDecimal ?? '0')}
+            nativeTokenSymbol={nativeTokenSymbol}
+            nativeTokenPrice={nativeToken?.price}
+          />
+        ),
         onSuccess: hideModal,
         onFailure: hideModal,
       });

--- a/src/core/util.tsx
+++ b/src/core/util.tsx
@@ -1456,7 +1456,11 @@ export const getMinimumCardLoadAmount = (
   if (tokenData?.accountType === 'spot') return MINIMUM_TRANSFER_AMOUNT_HL_SPOT;
   if (tokenData?.chainDetails?.backendName === CHAIN_ETH.backendName) {
     const coinGeckoId =
-      tokenData && 'coinGeckoId' in tokenData ? tokenData.coinGeckoId : '';
+      tokenData && 'coinGeckoId' in tokenData
+        ? tokenData.coinGeckoId
+        : tokenData && 'coingeckoId' in tokenData
+        ? tokenData.coingeckoId.toLowerCase()
+        : '';
     if (!['usd-coin', 'tether'].includes(coinGeckoId)) {
       return MINIMUM_TRANSFER_AMOUNT_ETH;
     }

--- a/src/core/util.tsx
+++ b/src/core/util.tsx
@@ -1452,16 +1452,16 @@ export const formatCurrencyWithSuffix = (value: number): string => {
 
 export const getMinimumCardLoadAmount = (
   tokenData: Holding | IHyperLiquidHolding | undefined,
-) => {
-  // hyperliquid spot account $15
-  // eth $50
-  // all other $10
-
-  return tokenData?.accountType === 'spot'
-    ? MINIMUM_TRANSFER_AMOUNT_HL_SPOT
-    : tokenData?.chainDetails?.backendName === CHAIN_ETH.backendName
-    ? MINIMUM_TRANSFER_AMOUNT_ETH
-    : 10;
+): number => {
+  if (tokenData?.accountType === 'spot') return MINIMUM_TRANSFER_AMOUNT_HL_SPOT;
+  if (tokenData?.chainDetails?.backendName === CHAIN_ETH.backendName) {
+    const coinGeckoId =
+      tokenData && 'coinGeckoId' in tokenData ? tokenData.coinGeckoId : '';
+    if (!['usd-coin', 'tether'].includes(coinGeckoId)) {
+      return MINIMUM_TRANSFER_AMOUNT_ETH;
+    }
+  }
+  return 10;
 };
 
 export const extractAddressFromURI = (content: string): string => {

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1646,6 +1646,11 @@ const resources = {
       MAXIMUM_AMOUNT_POSSIBLE: 'Enter amount less than ',
       INSUFFICIENT_FUNDS_DESCRIPTION: `Your balance isn't sufficient to cover both the amount and the load fee. Use the 'Max' option to load the maximum amount possible`,
       INSUFFICIENT_GAS_FEE_DESCRIPTION: `Your native token balance isn't sufficient to cover the gas fee.`,
+      INSUFFICIENT_GAS_FEE_INTRO: `Your {{symbol}} balance isn't enough to cover the network fee.`,
+      INSUFFICIENT_GAS_FEE_REQUIRED: 'Required',
+      INSUFFICIENT_GAS_FEE_AVAILABLE: 'You have',
+      INSUFFICIENT_GAS_FEE_ESTIMATE_NOTE:
+        'This is an estimated gas fee. Actual cost may be lower.',
       GAS_FEE_ERROR: 'Gas Fee Estimation Failed',
       GAS_FEE_ERROR_DESCRIPTION:
         'Gas fee estimation failed. Please try again later. Contact support if the issue persists.',


### PR DESCRIPTION
  min-load rule and improve gas
  fee modal

  - Carve out ETH USDC/USDT at min in getMinimumCardLoadAmount
  - Use the utility in fundCard auto-select filter and suggestedAmounts baseline
  - Delegate chooseTokenModalV2 getMinimumTokenValue to the utility
  - Add InsufficientGasFeeDescription component showing required vs available with USD
  - Wire the new component into fundCard, Browser, enterAmount, and IBC gas-fee modals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error messaging for insufficient gas: shows required vs available amounts in native currency and USD estimates when price is available, plus an informational note.

* **Bug Fixes**
  * Standardized minimum card-load calculations so token eligibility and suggested funding are more consistent.

* **Localization**
  * Added English translations for gas fee error messages and informational labels.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CypherD-IO/mobile-app/pull/892)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->