### PR TITLE
Add local notification inbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ if (isE2ETesting) {
 }
 import { name as appName } from './app.json';
 import { showNotification } from './src/notification/pushNotification';
+import { saveNotificationInboxItem } from './src/notification/notificationInbox';
 import Sentry from '@sentry/react-native';
 
 /**
@@ -71,10 +72,18 @@ if (__DEV__) {
 if (!isE2ETesting) {
   messaging().setBackgroundMessageHandler(async remoteMessage => {
     try {
+      // Local inbox archive only captures background messages that reach this
+      // JavaScript handler; OS/native-rendered notifications may still bypass it.
+      await saveNotificationInboxItem(remoteMessage, {
+        source: 'firebase-background',
+      });
+
       const handled =
         await CustomerIO.pushMessaging.onBackgroundMessageReceived(remoteMessage);
       if (!handled) {
-        await showNotification(remoteMessage.notification, remoteMessage.data);
+        await showNotification(remoteMessage.notification, remoteMessage.data, {
+          messageId: remoteMessage.messageId,
+        });
       }
     } catch (e) {
       Sentry.captureException(e);

--- a/src/components/initializeAppProvider/index.tsx
+++ b/src/components/initializeAppProvider/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import useInitializer from '../../hooks/useInitializer';
 import { GlobalContext, GlobalContextDef } from '../../core/globalContext';
 import { Alert, Linking, Platform } from 'react-native';
@@ -47,6 +47,10 @@ import PinAuthRoute from '../../routes/pinAuthRoute';
 import { AnalyticEvent, logAnalyticsToFirebase } from '../../core/analytics';
 import { CustomerIO } from 'customerio-reactnative';
 import useCustomerIO from '../../hooks/useCustomerIO';
+import {
+  getNotificationInboxScope,
+  saveNotificationInboxItem,
+} from '../../notification/notificationInbox';
 
 interface UseInitializerReturn {
   exitIfJailBroken: () => Promise<void>;
@@ -121,6 +125,13 @@ export const InitializeAppProvider = ({
 
   // State to track if wallet data is still loading
   const [walletLoading, setWalletLoading] = useState<boolean>(true);
+  const notificationInboxScopeRef = useRef<string | undefined>(
+    getNotificationInboxScope(hdWallet?.state),
+  );
+
+  useEffect(() => {
+    notificationInboxScopeRef.current = getNotificationInboxScope(hdWallet?.state);
+  }, [hdWallet?.state]);
 
   useEffect(() => {
     const isE2ETesting = Config.IS_TESTING === 'true';
@@ -130,8 +141,14 @@ export const InitializeAppProvider = ({
     // periodic firelog/firebase-settings polls). Tests never exercise push
     // notifications, so no coverage lost.
     const unsubscribeOnMessage = isE2ETesting
-      ? () => {}
+      ? () => undefined
       : onMessage(getMessaging(), async response => {
+          const notificationInboxScope = notificationInboxScopeRef.current;
+          await saveNotificationInboxItem(response, {
+            source: 'firebase-foreground',
+            scopeId: notificationInboxScope,
+          });
+
           let handledByCio = false;
           try {
             handledByCio =
@@ -163,9 +180,10 @@ export const InitializeAppProvider = ({
               });
             }, 1000);
           } else {
-            void showNotification(response.notification, response.data).catch(
-              Sentry.captureException,
-            );
+            void showNotification(response.notification, response.data, {
+              messageId: response.messageId,
+              scopeId: notificationInboxScope,
+            }).catch(Sentry.captureException);
           }
         });
 

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -24,6 +24,7 @@ export const screenTitle = {
   SEED_PHRASE: 'SeedPhrase',
   PRIVATE_KEY: 'PrivateKey',
   NOTIFICATION_SETTINGS: 'NotificationSettings',
+  NOTIFICATION_INBOX: 'NotificationInbox',
   IMPORT_ANOTHER_WALLET: 'ImportAnotherWallet',
   DELETE_WALLET: 'DeleteWallet',
   QRCODE: 'QrCode',

--- a/src/containers/Notifications/NotificationInbox.tsx
+++ b/src/containers/Notifications/NotificationInbox.tsx
@@ -1,0 +1,401 @@
+import {
+  NavigationProp,
+  ParamListBase,
+  useIsFocused,
+  useNavigation,
+} from '@react-navigation/native';
+import moment from 'moment';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { GestureResponderEvent, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useGlobalModalContext } from '../../components/v2/GlobalModal';
+import { GlobalModalType } from '../../constants/enum';
+import { HdWalletContext } from '../../core/util';
+import {
+  deleteNotificationInboxItem,
+  getNotificationInboxItems,
+  getNotificationInboxScope,
+  markAllNotificationInboxItemsRead,
+  markNotificationInboxItemRead,
+  NOTIFICATION_INBOX_DEVICE_SCOPE,
+} from '../../notification/notificationInbox';
+import { routeNotificationInboxAction } from '../../notification/pushNotification';
+import type {
+  NotificationInboxCategory,
+  NotificationInboxItem,
+} from '../../notification/notificationInbox';
+import type { HdWalletContextDef } from '../../reducers/hdwallet_reducer';
+import {
+  CyDMaterialDesignIcons,
+  CyDScrollView,
+  CyDText,
+  CyDTouchView,
+  CyDView,
+} from '../../styles/tailwindComponents';
+
+type FilterKey = 'all' | 'unread' | NotificationInboxCategory;
+
+interface FilterOption {
+  key: FilterKey;
+  labelKey: string;
+}
+
+const FILTER_OPTIONS: FilterOption[] = [
+  { key: 'all', labelKey: 'NOTIFICATION_INBOX_ALL' },
+  { key: 'unread', labelKey: 'NOTIFICATION_INBOX_UNREAD' },
+  { key: 'card', labelKey: 'NOTIFICATION_INBOX_CATEGORY_CARD' },
+  { key: 'security', labelKey: 'NOTIFICATION_INBOX_CATEGORY_SECURITY' },
+  { key: 'rewards', labelKey: 'NOTIFICATION_INBOX_CATEGORY_REWARDS' },
+  { key: 'bridgeSwap', labelKey: 'NOTIFICATION_INBOX_CATEGORY_BRIDGE_SWAP' },
+  { key: 'quickAction', labelKey: 'NOTIFICATION_INBOX_CATEGORY_QUICK_ACTION' },
+];
+
+const CATEGORY_LABEL_KEYS: Record<NotificationInboxCategory, string> = {
+  card: 'NOTIFICATION_INBOX_CATEGORY_CARD',
+  security: 'NOTIFICATION_INBOX_CATEGORY_SECURITY',
+  rewards: 'NOTIFICATION_INBOX_CATEGORY_REWARDS',
+  bridgeSwap: 'NOTIFICATION_INBOX_CATEGORY_BRIDGE_SWAP',
+  quickAction: 'NOTIFICATION_INBOX_CATEGORY_QUICK_ACTION',
+  general: 'NOTIFICATION_INBOX_CATEGORY_GENERAL',
+};
+
+const getActionHintKey = (item: NotificationInboxItem) => {
+  if (item.action.type === 'quickAction') {
+    return 'NOTIFICATION_INBOX_TAKE_ACTION';
+  }
+
+  if (item.category === 'security') {
+    return 'NOTIFICATION_INBOX_REVIEW';
+  }
+
+  if (item.action.type === 'navigate') {
+    return 'NOTIFICATION_INBOX_OPEN';
+  }
+
+  return 'NOTIFICATION_INBOX_VIEW_DETAILS';
+};
+
+const formatNotificationTimestamp = (timestamp: number) => {
+  const receivedAt = moment(timestamp);
+  if (moment().diff(receivedAt, 'days') < 7) {
+    return receivedAt.fromNow();
+  }
+  return receivedAt.format('MMM D, YYYY');
+};
+
+const styles = StyleSheet.create({
+  filterContent: {
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  listContent: {
+    paddingBottom: 24,
+    flexGrow: 1,
+  },
+});
+
+const getVisibleMarkAllScopes = (scopeId?: string) => {
+  const scopes = [scopeId, NOTIFICATION_INBOX_DEVICE_SCOPE].filter(
+    (scope): scope is string => !!scope,
+  );
+  return Array.from(new Set(scopes));
+};
+
+interface NotificationInboxFiltersProps {
+  selectedFilter: FilterKey;
+  onSelectFilter: (filter: FilterKey) => void;
+  t: (key: string) => string;
+}
+
+function NotificationInboxFiltersComponent({
+  selectedFilter,
+  onSelectFilter,
+  t,
+}: NotificationInboxFiltersProps) {
+  return (
+    <CyDScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      className='max-h-[44px]'
+      contentContainerStyle={styles.filterContent}>
+      {FILTER_OPTIONS.map(filter => {
+        const isSelected = filter.key === selectedFilter;
+        return (
+          <CyDTouchView
+            key={filter.key}
+            onPress={() => onSelectFilter(filter.key)}
+            className={`px-[14px] py-[8px] rounded-full border ${
+              isSelected ? 'bg-base400 border-base400' : 'bg-n0 border-n40'
+            }`}>
+            <CyDText
+              className={`text-[13px] font-semibold ${
+                isSelected ? 'text-n0' : 'text-base400'
+              }`}>
+              {t(filter.labelKey)}
+            </CyDText>
+          </CyDTouchView>
+        );
+      })}
+    </CyDScrollView>
+  );
+}
+
+const NotificationInboxFilters = React.memo(NotificationInboxFiltersComponent);
+
+function NotificationInboxEmptyStateComponent({ t }: { t: (key: string) => string }) {
+  return <CyDView className='flex-1 items-center justify-center px-[28px] py-[72px]'>
+    <CyDView className='h-[64px] w-[64px] rounded-full bg-n20 items-center justify-center mb-[18px]'>
+      <CyDMaterialDesignIcons
+        name='bell-outline'
+        size={32}
+        className='text-base400'
+      />
+    </CyDView>
+    <CyDText className='text-[18px] font-bold text-center text-base400 mb-[8px]'>
+      {t('NOTIFICATION_INBOX_EMPTY_TITLE')}
+    </CyDText>
+    <CyDText className='text-[14px] font-medium text-center text-n200 leading-[22px]'>
+      {t('NOTIFICATION_INBOX_EMPTY_SUBTITLE')}
+    </CyDText>
+  </CyDView>;
+}
+
+const NotificationInboxEmptyState = React.memo(NotificationInboxEmptyStateComponent);
+
+interface NotificationInboxCardProps {
+  item: NotificationInboxItem;
+  onPress: (item: NotificationInboxItem) => void;
+  onDelete: (event: GestureResponderEvent, item: NotificationInboxItem) => void;
+  t: (key: string) => string;
+}
+
+function NotificationInboxCardComponent({
+  item,
+  onPress,
+  onDelete,
+  t,
+}: NotificationInboxCardProps) {
+    const isUnread = item.status === 'unread';
+    return (
+      <CyDTouchView
+        activeOpacity={0.8}
+        onPress={() => onPress(item)}
+        className={`mx-[16px] mb-[12px] rounded-[18px] border p-[16px] ${
+          isUnread ? 'bg-n0 border-base400' : 'bg-n0 border-n40'
+        }`}>
+        <CyDView className='flex-row items-start justify-between gap-[12px]'>
+          <CyDView className='flex-1'>
+            <CyDView className='flex-row items-center mb-[8px]'>
+              {isUnread && (
+                <CyDView className='h-[8px] w-[8px] rounded-full bg-base400 mr-[8px]' />
+              )}
+              <CyDText className='text-[12px] font-bold uppercase text-base400'>
+                {t(CATEGORY_LABEL_KEYS[item.category])}
+              </CyDText>
+              <CyDText className='text-[12px] font-medium text-n100 ml-[8px]'>
+                {formatNotificationTimestamp(item.receivedAt)}
+              </CyDText>
+            </CyDView>
+            <CyDText className='text-[16px] font-bold text-base400 mb-[6px]'>
+              {item.title}
+            </CyDText>
+            {!!item.body && (
+              <CyDText
+                className='text-[14px] font-medium text-n200 leading-[20px] mb-[12px]'
+                numberOfLines={3}>
+                {item.body}
+              </CyDText>
+            )}
+            <CyDText className='text-[13px] font-bold text-base400'>
+              {t(getActionHintKey(item))}
+            </CyDText>
+          </CyDView>
+          <CyDTouchView
+            accessibilityLabel={t('DELETE') ?? 'Delete'}
+            onPress={event => onDelete(event, item)}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            className='h-[32px] w-[32px] rounded-full bg-n20 items-center justify-center'>
+            <CyDMaterialDesignIcons
+              name='trash-can-outline'
+              size={20}
+              className='text-base400'
+            />
+          </CyDTouchView>
+        </CyDView>
+      </CyDTouchView>
+    );
+}
+
+const NotificationInboxCard = React.memo(NotificationInboxCardComponent);
+
+export const markVisibleNotificationInboxItemsRead = async (scopeId?: string) => {
+  await Promise.all(
+    getVisibleMarkAllScopes(scopeId).map(async visibleScopeId =>
+      await markAllNotificationInboxItemsRead({ scopeId: visibleScopeId }),
+    ),
+  );
+};
+
+export const markVisibleNotificationInboxItemRead = async (
+  item: NotificationInboxItem,
+) => await markNotificationInboxItemRead(item.id, { scopeId: item.scopeId });
+
+export const deleteVisibleNotificationInboxItem = async (
+  item: NotificationInboxItem,
+) => await deleteNotificationInboxItem(item.id, { scopeId: item.scopeId });
+
+export const pressNotificationInboxItem = async ({
+  item,
+  navigation,
+  showModal,
+  hideModal,
+}: {
+  item: NotificationInboxItem;
+  navigation: NavigationProp<ParamListBase>;
+  showModal: (type: GlobalModalType, data: unknown) => void;
+  hideModal: () => void;
+}) => {
+  await markVisibleNotificationInboxItemRead(item);
+  await routeNotificationInboxAction({
+    item,
+    navigation,
+    showModal,
+    hideModal,
+  });
+};
+
+export default function NotificationInbox() {
+  const { t } = useTranslation();
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const { showModal, hideModal } = useGlobalModalContext();
+  const isFocused = useIsFocused();
+  const hdWalletContext = useContext(HdWalletContext) as HdWalletContextDef;
+  const scopeId = useMemo(
+    () => getNotificationInboxScope(hdWalletContext?.state),
+    [hdWalletContext?.state],
+  );
+  const [items, setItems] = useState<NotificationInboxItem[]>([]);
+  const [selectedFilter, setSelectedFilter] = useState<FilterKey>('all');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadItems = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const inboxItems = await getNotificationInboxItems({
+        scopeId,
+        includeDeviceScope: true,
+      });
+      setItems(inboxItems);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [scopeId]);
+
+  useEffect(() => {
+    if (isFocused) {
+      loadItems().catch(() => undefined);
+    }
+  }, [isFocused, loadItems]);
+
+  const filteredItems = useMemo(() => {
+    switch (selectedFilter) {
+      case 'all':
+        return items;
+      case 'unread':
+        return items.filter(item => item.status === 'unread');
+      default:
+        return items.filter(item => item.category === selectedFilter);
+    }
+  }, [items, selectedFilter]);
+
+  const hasUnreadItems = useMemo(
+    () => items.some(item => item.status === 'unread'),
+    [items],
+  );
+
+  const handleMarkAllRead = useCallback(async () => {
+    await markVisibleNotificationInboxItemsRead(scopeId);
+    await loadItems();
+  }, [loadItems, scopeId]);
+
+  const handlePressItem = useCallback(
+    async (item: NotificationInboxItem) => {
+      await pressNotificationInboxItem({
+        item,
+        navigation,
+        showModal,
+        hideModal,
+      });
+      await loadItems();
+    },
+    [hideModal, loadItems, navigation, showModal],
+  );
+
+  const handleDeleteItem = useCallback(
+    async (event: GestureResponderEvent, item: NotificationInboxItem) => {
+      event.stopPropagation?.();
+      await deleteVisibleNotificationInboxItem(item);
+      await loadItems();
+    },
+    [loadItems],
+  );
+
+  const handleSelectFilter = useCallback((filter: FilterKey) => {
+    setSelectedFilter(filter);
+  }, []);
+
+  const handlePressCard = useCallback(
+    (item: NotificationInboxItem) => {
+      handlePressItem(item).catch(() => undefined);
+    },
+    [handlePressItem],
+  );
+
+  const handleDeleteCard = useCallback(
+    (event: GestureResponderEvent, item: NotificationInboxItem) => {
+      handleDeleteItem(event, item).catch(() => undefined);
+    },
+    [handleDeleteItem],
+  );
+
+  return (
+    <CyDView className='flex-1 bg-n20'>
+      <CyDView className='py-[12px]'>
+        <NotificationInboxFilters
+          selectedFilter={selectedFilter}
+          onSelectFilter={handleSelectFilter}
+          t={t}
+        />
+      </CyDView>
+      {hasUnreadItems && (
+        <CyDView className='px-[16px] pb-[12px] items-end'>
+          <CyDTouchView
+            onPress={() => {
+              handleMarkAllRead().catch(() => undefined);
+            }}>
+            <CyDText className='text-[14px] font-bold text-base400'>
+              {t('NOTIFICATION_INBOX_MARK_ALL_READ')}
+            </CyDText>
+          </CyDTouchView>
+        </CyDView>
+      )}
+      <CyDScrollView
+        className='flex-1'
+        contentContainerStyle={styles.listContent}>
+        {filteredItems.length === 0 && !isLoading ? (
+          <NotificationInboxEmptyState t={t} />
+        ) : (
+          filteredItems.map(item => (
+            <NotificationInboxCard
+              key={item.id}
+              item={item}
+              onPress={handlePressCard}
+              onDelete={handleDeleteCard}
+              t={t}
+            />
+          ))
+        )}
+      </CyDScrollView>
+    </CyDView>
+  );
+}

--- a/src/containers/Notifications/__tests__/NotificationInbox.test.tsx
+++ b/src/containers/Notifications/__tests__/NotificationInbox.test.tsx
@@ -1,0 +1,185 @@
+/* eslint-disable import/first, import/no-duplicates, @typescript-eslint/no-var-requires */
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(() => false),
+  useNavigation: jest.fn(() => ({ navigate: jest.fn() })),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../../components/v2/GlobalModal', () => ({
+  useGlobalModalContext: () => ({ showModal: jest.fn(), hideModal: jest.fn() }),
+}));
+
+jest.mock('../../../core/util', () => {
+  const React = require('react');
+  return {
+    HdWalletContext: React.createContext({ state: {} }),
+  };
+});
+
+jest.mock('../../../styles/tailwindComponents', () => {
+  const { ScrollView, Text, TouchableOpacity, View } = require('react-native');
+  return {
+    CyDMaterialDesignIcons: View,
+    CyDScrollView: ScrollView,
+    CyDText: Text,
+    CyDTouchView: TouchableOpacity,
+    CyDView: View,
+  };
+});
+
+jest.mock('../../../notification/notificationInbox', () => ({
+  deleteNotificationInboxItem: jest.fn(),
+  getNotificationInboxItems: jest.fn(async () => []),
+  getNotificationInboxScope: jest.fn(() => 'wallet-scope'),
+  markAllNotificationInboxItemsRead: jest.fn(async () => []),
+  markNotificationInboxItemRead: jest.fn(),
+  NOTIFICATION_INBOX_DEVICE_SCOPE: 'device',
+}));
+
+jest.mock('../../../notification/pushNotification', () => ({
+  routeNotificationInboxAction: jest.fn(async () => undefined),
+}));
+
+import {
+  deleteNotificationInboxItem,
+  getNotificationInboxItems,
+  markAllNotificationInboxItemsRead,
+  markNotificationInboxItemRead,
+} from '../../../notification/notificationInbox';
+import { routeNotificationInboxAction } from '../../../notification/pushNotification';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import NotificationInbox from '../NotificationInbox';
+import {
+  deleteVisibleNotificationInboxItem,
+  markVisibleNotificationInboxItemRead,
+  markVisibleNotificationInboxItemsRead,
+  pressNotificationInboxItem,
+} from '../NotificationInbox';
+
+const navigationMock = { navigate: jest.fn() };
+
+const mockDeleteItem = deleteNotificationInboxItem as jest.Mock;
+const mockGetItems = getNotificationInboxItems as jest.Mock;
+const mockMarkAll = markAllNotificationInboxItemsRead as jest.Mock;
+const mockMarkItemRead = markNotificationInboxItemRead as jest.Mock;
+const mockRouteInboxAction = routeNotificationInboxAction as jest.Mock;
+const mockUseIsFocused = require('@react-navigation/native').useIsFocused as jest.Mock;
+const mockUseNavigation = require('@react-navigation/native').useNavigation as jest.Mock;
+
+describe('NotificationInbox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItems.mockResolvedValue([]);
+    mockUseIsFocused.mockReturnValue(false);
+    mockUseNavigation.mockReturnValue(navigationMock);
+  });
+
+  it('marks both wallet-scoped and device fallback items read when a wallet scope is visible', async () => {
+    await markVisibleNotificationInboxItemsRead('wallet-scope');
+
+    expect(mockMarkAll).toHaveBeenCalledTimes(2);
+    expect(mockMarkAll).toHaveBeenNthCalledWith(1, { scopeId: 'wallet-scope' });
+    expect(mockMarkAll).toHaveBeenNthCalledWith(2, { scopeId: 'device' });
+  });
+
+  it('marks device fallback items once when no wallet scope is available', async () => {
+    await markVisibleNotificationInboxItemsRead(undefined);
+
+    expect(mockMarkAll).toHaveBeenCalledTimes(1);
+    expect(mockMarkAll).toHaveBeenCalledWith({ scopeId: 'device' });
+  });
+
+  it('uses each item scope for per-item mark-read and delete operations', async () => {
+    const item = {
+      id: 'item-1',
+      scopeId: 'wallet-scope',
+    } as any;
+
+    await markVisibleNotificationInboxItemRead(item);
+    await deleteVisibleNotificationInboxItem(item);
+
+    expect(mockMarkItemRead).toHaveBeenCalledWith('item-1', {
+      scopeId: 'wallet-scope',
+    });
+    expect(mockDeleteItem).toHaveBeenCalledWith('item-1', {
+      scopeId: 'wallet-scope',
+    });
+  });
+
+  it('marks tapped items read and routes them through the safe inbox action helper', async () => {
+    const item = {
+      id: 'quick-action-item',
+      scopeId: 'wallet-scope',
+      action: { type: 'quickAction', actionId: 'ADD_COUNTRY' },
+    } as any;
+    const navigation = { navigate: jest.fn() } as any;
+    const showModal = jest.fn();
+    const hideModal = jest.fn();
+
+    await pressNotificationInboxItem({
+      item,
+      navigation,
+      showModal,
+      hideModal,
+    });
+
+    expect(mockMarkItemRead).toHaveBeenCalledWith('quick-action-item', {
+      scopeId: 'wallet-scope',
+    });
+    expect(mockRouteInboxAction).toHaveBeenCalledWith({
+      item,
+      navigation,
+      showModal,
+      hideModal,
+    });
+  });
+
+  it('renders the empty state when focused with no inbox items', async () => {
+    mockUseIsFocused.mockReturnValue(true);
+    mockGetItems.mockResolvedValue([]);
+
+    render(<NotificationInbox />);
+
+    expect(await screen.findByText('NOTIFICATION_INBOX_EMPTY_TITLE')).toBeTruthy();
+    expect(screen.getByText('NOTIFICATION_INBOX_EMPTY_SUBTITLE')).toBeTruthy();
+  });
+
+  it('renders unread actions and supports mark-all-read, delete, and tap interactions', async () => {
+    mockUseIsFocused.mockReturnValue(true);
+    const item = {
+      id: 'item-1',
+      scopeId: 'wallet-scope',
+      title: 'Card declined',
+      body: 'Review this card transaction',
+      category: 'card',
+      status: 'unread',
+      receivedAt: Date.now(),
+      action: { type: 'navigate', tab: 'CARD', screen: 'DEBIT_CARD_SCREEN' },
+    } as any;
+    mockGetItems.mockResolvedValue([item]);
+
+    render(<NotificationInbox />);
+
+    expect(await screen.findByText('Card declined')).toBeTruthy();
+    expect(screen.getByText('NOTIFICATION_INBOX_MARK_ALL_READ')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('NOTIFICATION_INBOX_MARK_ALL_READ'));
+    await waitFor(() => expect(mockMarkAll).toHaveBeenCalledWith({ scopeId: 'wallet-scope' }));
+
+    fireEvent(screen.getByLabelText('DELETE'), 'press', {
+      stopPropagation: jest.fn(),
+    });
+    await waitFor(() => expect(mockDeleteItem).toHaveBeenCalledWith('item-1', { scopeId: 'wallet-scope' }));
+
+    mockGetItems.mockResolvedValue([item]);
+    fireEvent.press(screen.getByText('Card declined'));
+    await waitFor(() => expect(mockMarkItemRead).toHaveBeenCalledWith('item-1', { scopeId: 'wallet-scope' }));
+    expect(mockRouteInboxAction).toHaveBeenCalledWith(
+      expect.objectContaining({ item }),
+    );
+  });
+});

--- a/src/containers/Portfolio/components/HeaderBar.tsx
+++ b/src/containers/Portfolio/components/HeaderBar.tsx
@@ -21,6 +21,7 @@ import useEns from '../../../hooks/useEns';
 import { HdWalletContextDef } from '../../../reducers/hdwallet_reducer';
 import {
   CyDIcons,
+  CyDMaterialDesignIcons,
   CyDImage,
   CyDText,
   CyDTouchView,
@@ -30,9 +31,12 @@ import { get } from 'lodash';
 import type { QRScanEvent } from '../../../types/qr';
 
 interface HeaderBarProps {
-  navigation: any;
+  navigation: { navigate: (screen: string, params?: unknown) => void };
   onWCSuccess: (e: QRScanEvent) => void;
   selectedChain: Chain;
+  rightIconName?: string;
+  rightActionAccessibilityLabel?: string;
+  onRightActionPress?: () => void;
 }
 
 /**
@@ -57,6 +61,9 @@ export const HeaderBar = ({
   navigation,
   onWCSuccess,
   selectedChain,
+  rightIconName,
+  rightActionAccessibilityLabel,
+  onRightActionPress,
 }: HeaderBarProps) => {
   const hdWalletContext = useContext(HdWalletContext) as HdWalletContextDef;
   const { wallet } = hdWalletContext.state;
@@ -224,6 +231,18 @@ export const HeaderBar = ({
             gradientColors={['#FA9703', '#F89408', '#F6510A']}
             locations={[0, 0.3, 0.6]}
           />
+        )}
+
+        {onRightActionPress && (
+          <CyDTouchView
+            accessibilityLabel={rightActionAccessibilityLabel}
+            onPress={onRightActionPress}>
+            <CyDMaterialDesignIcons
+              name={rightIconName ?? 'bell-outline'}
+              size={30}
+              className='text-base400'
+            />
+          </CyDTouchView>
         )}
 
         {connectionTypeValue !== ConnectionTypes.WALLET_CONNECT && (

--- a/src/containers/Portfolio/index.tsx
+++ b/src/containers/Portfolio/index.tsx
@@ -1,10 +1,4 @@
-import notifee, { EventType } from '@notifee/react-native';
-import {
-  FirebaseMessagingTypes,
-  getInitialNotification,
-  getMessaging,
-  onNotificationOpenedApp,
-} from '@react-native-firebase/messaging';
+import { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import {
   ParamListBase,
   useIsFocused,
@@ -83,7 +77,7 @@ import {
 import usePortfolio from '../../hooks/usePortfolio';
 import { DeFiFilter } from '../../models/defi.interface';
 import { IPortfolioData } from '../../models/portfolioData.interface';
-import { RouteNotificationAction } from '../../notification/pushNotification';
+import { getNotificationInboxScope } from '../../notification/notificationInbox';
 import {
   BridgeContext,
   BridgeContextDef,
@@ -112,6 +106,7 @@ import { AnalyticEvent, logAnalyticsToFirebase } from '../../core/analytics';
 import GetTokenBottomSheetContent from '../../components/v2/GetTokenBottomSheetContent';
 import { useGlobalBottomSheet } from '../../components/v2/GlobalBottomSheetProvider';
 import useBridgeV2Sheet from '../../features/bridgeV2/hooks/useBridgeV2Sheet';
+import useNotificationOpenHandlers from '../../hooks/useNotificationOpenHandlers';
 import { Theme, useTheme } from '../../reducers/themeReducer';
 import { colorScheme } from 'nativewind';
 import CyDModalLayout from '../../components/v2/modal';
@@ -120,6 +115,7 @@ import type { QRScanEvent } from '../../types/qr';
 export interface PortfolioProps {
   navigation: NativeStackNavigationProp<ParamListBase>;
 }
+
 
 interface IBuyOptionsData {
   index: number;
@@ -173,6 +169,10 @@ export default function Portfolio({ navigation }: PortfolioProps) {
     false;
   const globalStateContext = useContext(GlobalContext);
   const hdWallet = useContext(HdWalletContext);
+  const notificationInboxScope = useMemo(
+    () => getNotificationInboxScope(hdWallet?.state),
+    [hdWallet?.state],
+  );
   const [isPortfolioLoading, setIsPortfolioLoading] = useState<boolean>();
   const [isPortfolioRefreshing, setIsPortfolioRefreshing] =
     useState<boolean>(false);
@@ -600,6 +600,7 @@ export default function Portfolio({ navigation }: PortfolioProps) {
   ];
   const [tabIndex, setTabIndex] = useState<number>(0);
 
+  // eslint-disable-next-line @typescript-eslint/array-type
   const swipeableRefs: Array<Swipeable | null> = [];
   let previousOpenedSwipeableRef: Swipeable | null;
 
@@ -793,71 +794,15 @@ export default function Portfolio({ navigation }: PortfolioProps) {
     }
   };
 
+  useNotificationOpenHandlers({
+    navigation,
+    showModal,
+    hideModal,
+    notificationInboxScope,
+    onPushNotification: handlePushNotification,
+  });
+
   useEffect(() => {
-    const messagingInstance = getMessaging();
-    void getInitialNotification(messagingInstance)
-      .then(async response => {
-        await handlePushNotification(response);
-      })
-      .catch(error => {
-        Sentry.captureException(error);
-      });
-
-    const unsubscribeNotificationOpenedApp = onNotificationOpenedApp(
-      messagingInstance,
-      async response => {
-        await handlePushNotification(response);
-      },
-    );
-
-    notifee
-      .getInitialNotification()
-      .then(async response => {
-        if (response?.notification) {
-          await handlePushNotification(response?.notification as any);
-        }
-      })
-      .catch(error => {
-        Sentry.captureException(error);
-      });
-
-    notifee.onBackgroundEvent(async remoteMessage => {
-      const { type, detail } = remoteMessage;
-
-      if (type === EventType.ACTION_PRESS) {
-        const { notification, pressAction } = detail;
-        if (notification?.id && pressAction?.id) {
-          await RouteNotificationAction({
-            notificationId: notification?.id,
-            actionId: pressAction?.id,
-            data: notification?.data,
-            navigation,
-            showModal,
-            hideModal,
-          });
-        }
-      }
-    });
-
-    const unsubscribe = notifee.onForegroundEvent(remoteMessage => {
-      const { type, detail } = remoteMessage;
-      if (type === EventType.ACTION_PRESS) {
-        const { notification, pressAction } = detail;
-        if (notification?.id && pressAction?.id) {
-          RouteNotificationAction({
-            notificationId: notification?.id,
-            actionId: pressAction?.id,
-            data: notification?.data,
-            navigation,
-            showModal,
-            hideModal,
-          }).catch(error => {
-            Sentry.captureException(error);
-          });
-        }
-      }
-    });
-
     const getIBCStatus = async () => {
       const data = await getIBC();
       let IBCStatus = false;
@@ -874,10 +819,6 @@ export default function Portfolio({ navigation }: PortfolioProps) {
     });
 
     void getBridgeData().catch;
-    return () => {
-      unsubscribe();
-      unsubscribeNotificationOpenedApp();
-    };
   }, []);
 
   useEffect(() => {
@@ -1361,6 +1302,11 @@ export default function Portfolio({ navigation }: PortfolioProps) {
               navigation={navigation}
               onWCSuccess={onWCSuccess}
               selectedChain={selectedChain}
+              rightIconName='bell-outline'
+              rightActionAccessibilityLabel={t('NOTIFICATION_INBOX')}
+              onRightActionPress={() =>
+                navigation.navigate(C.screenTitle.NOTIFICATION_INBOX)
+              }
             />
           </CyDView>
           <SectionList

--- a/src/core/__tests__/asyncStorage.test.ts
+++ b/src/core/__tests__/asyncStorage.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable import/first */
+jest.mock('../../containers/Options/advancedSettings', () => ({
+  advancedSettingsInitialState: {},
+}));
+
+jest.mock('../util', () => ({
+  CYPHERD_ROOT_DATA: 'CYPHERD_ROOT_DATA',
+}));
+
+jest.mock('../portfolio', () => ({}));
+
+jest.mock('../../constants/data', () => ({
+  ASYNC_STORAGE_KEYS_TO_PRESERVE: ['ARCH_HOST'],
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { clearAllData } from '../asyncStorage';
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage> & {
+  multiRemove: jest.Mock;
+};
+
+describe('clearAllData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAsyncStorage.multiRemove = jest.fn(async () => undefined);
+  });
+
+  it('removes notification inbox keys because they are not preserved', async () => {
+    mockAsyncStorage.getAllKeys.mockResolvedValue([
+      'ARCH_HOST',
+      'CONTACT_BOOK',
+      'CONTACT_BOOK:0xabc',
+      'notificationInbox.v1:0xabc',
+      'notificationInbox.v1:device',
+      'wallet-data',
+    ] as never);
+
+    await clearAllData();
+
+    expect(mockAsyncStorage.multiRemove).toHaveBeenCalledWith([
+      'notificationInbox.v1:0xabc',
+      'notificationInbox.v1:device',
+      'wallet-data',
+    ]);
+  });
+});

--- a/src/hooks/useConnectionManager/index.tsx
+++ b/src/hooks/useConnectionManager/index.tsx
@@ -36,6 +36,7 @@ import useWalletConnectMobile from '../useWalletConnectMobile';
 import Web3Auth from '@web3auth/react-native-sdk/dist/types/Web3Auth';
 import useWeb3Auth from '../useWeb3Auth';
 import useCustomerIO from '../useCustomerIO';
+import { clearAllNotificationInboxScopes } from '../../notification/notificationInbox';
 
 export default function useConnectionManager() {
   const ARCH_HOST: string = hostWorker.getHost('ARCH_HOST');
@@ -67,6 +68,7 @@ export default function useConnectionManager() {
       await removeCredentialsFromKeychain();
     }
     await clearCustomerIOUser();
+    await clearAllNotificationInboxScopes();
     await clearAllData();
     await hdWalletContext.dispatch({ type: 'RESET_WALLET' });
     await activityContext.dispatch({ type: ActivityReducerAction.RESET });

--- a/src/hooks/useNotificationOpenHandlers.ts
+++ b/src/hooks/useNotificationOpenHandlers.ts
@@ -1,0 +1,188 @@
+import notifee, { EventType } from '@notifee/react-native';
+import {
+  FirebaseMessagingTypes,
+  getInitialNotification,
+  getMessaging,
+  onNotificationOpenedApp,
+} from '@react-native-firebase/messaging';
+import { NavigationProp, ParamListBase } from '@react-navigation/native';
+import * as Sentry from '@sentry/react-native';
+import { useCallback, useEffect, useRef } from 'react';
+import { GlobalModalType } from '../constants/enum';
+import {
+  saveNotificationInboxItem,
+  NotificationInboxSource,
+} from '../notification/notificationInbox';
+import { RouteNotificationAction } from '../notification/pushNotification';
+
+let hasRegisteredNotifeeBackgroundEvent = false;
+let latestNotificationInboxScope: string | undefined;
+
+type PushNotificationHandler = (
+  remoteMessage: FirebaseMessagingTypes.RemoteMessage | null,
+) => Promise<void>;
+
+interface UseNotificationOpenHandlersParams {
+  navigation: NavigationProp<ParamListBase>;
+  showModal: (type: GlobalModalType, data: any) => void;
+  hideModal: () => void;
+  notificationInboxScope?: string;
+  onPushNotification: PushNotificationHandler;
+}
+
+export default function useNotificationOpenHandlers({
+  navigation,
+  showModal,
+  hideModal,
+  notificationInboxScope,
+  onPushNotification,
+}: UseNotificationOpenHandlersParams) {
+  const navigationRef = useRef(navigation);
+  const showModalRef = useRef(showModal);
+  const hideModalRef = useRef(hideModal);
+  const onPushNotificationRef = useRef(onPushNotification);
+
+  useEffect(() => {
+    latestNotificationInboxScope = notificationInboxScope;
+  }, [notificationInboxScope]);
+
+  useEffect(() => {
+    navigationRef.current = navigation;
+    showModalRef.current = showModal;
+    hideModalRef.current = hideModal;
+    onPushNotificationRef.current = onPushNotification;
+  });
+
+  const saveNotificationOpenToInbox = useCallback(
+    async (
+      notification: FirebaseMessagingTypes.RemoteMessage | any | null | undefined,
+      source: NotificationInboxSource,
+      markRead = false,
+    ) =>
+      await saveNotificationInboxItem(notification, {
+        source,
+        scopeId: latestNotificationInboxScope ?? notificationInboxScope,
+        markRead,
+      }),
+    [notificationInboxScope],
+  );
+
+  useEffect(() => {
+    const openPushNotification = async (
+      response: FirebaseMessagingTypes.RemoteMessage | null,
+    ) => {
+      await saveNotificationOpenToInbox(response, 'notifee-open', true);
+      await onPushNotificationRef.current(response);
+    };
+
+    const messagingInstance = getMessaging();
+    void getInitialNotification(messagingInstance)
+      .then(openPushNotification)
+      .catch(error => {
+        Sentry.captureException(error);
+      });
+
+    const unsubscribeNotificationOpenedApp = onNotificationOpenedApp(
+      messagingInstance,
+      openPushNotification,
+    );
+
+    notifee
+      .getInitialNotification()
+      .then(async response => {
+        if (response?.notification) {
+          await openPushNotification(response.notification as any);
+        }
+      })
+      .catch(error => {
+        Sentry.captureException(error);
+      });
+
+    if (!hasRegisteredNotifeeBackgroundEvent) {
+      hasRegisteredNotifeeBackgroundEvent = true;
+      notifee.onBackgroundEvent(async remoteMessage => {
+        const { type, detail } = remoteMessage;
+        const { notification, pressAction } = detail;
+
+        if (type === EventType.DISMISSED && notification) {
+          await saveNotificationInboxItem(notification as any, {
+            source: 'notifee-dismiss',
+            scopeId: latestNotificationInboxScope,
+          });
+          return;
+        }
+
+        if (type === EventType.PRESS && notification) {
+          await saveNotificationInboxItem(notification as any, {
+            source: 'notifee-open',
+            scopeId: latestNotificationInboxScope,
+            markRead: true,
+          });
+          return;
+        }
+
+        if (type === EventType.ACTION_PRESS && notification && pressAction?.id) {
+          await saveNotificationInboxItem(notification as any, {
+            source: 'notifee-action',
+            scopeId: latestNotificationInboxScope,
+            markRead: true,
+          });
+          if (notification.id) {
+            await RouteNotificationAction({
+              notificationId: notification.id,
+              actionId: pressAction.id,
+              data: notification.data,
+              navigation: navigationRef.current,
+              showModal: showModalRef.current,
+              hideModal: hideModalRef.current,
+            });
+          }
+        }
+      });
+    }
+
+    const unsubscribe = notifee.onForegroundEvent(remoteMessage => {
+      const { type, detail } = remoteMessage;
+      const { notification, pressAction } = detail;
+
+      if (type === EventType.DISMISSED && notification) {
+        saveNotificationOpenToInbox(notification as any, 'notifee-dismiss').catch(
+          error => {
+            Sentry.captureException(error);
+          },
+        );
+      }
+
+      if (type === EventType.PRESS && notification) {
+        openPushNotification(notification as any).catch(error => {
+          Sentry.captureException(error);
+        });
+      }
+
+      if (type === EventType.ACTION_PRESS && notification && pressAction?.id) {
+        saveNotificationOpenToInbox(notification as any, 'notifee-action', true)
+          .then(
+            async () =>
+              notification.id
+                ? await RouteNotificationAction({
+                    notificationId: notification.id,
+                    actionId: pressAction.id,
+                    data: notification?.data,
+                    navigation: navigationRef.current,
+                    showModal: showModalRef.current,
+                    hideModal: hideModalRef.current,
+                  })
+                : undefined,
+          )
+          .catch(error => {
+            Sentry.captureException(error);
+          });
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      unsubscribeNotificationOpenedApp();
+    };
+  }, [saveNotificationOpenToInbox]);
+}

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -10,6 +10,23 @@ const resources = {
   en: {
     translation: {
       english: 'English',
+      NOTIFICATION_INBOX: 'Notifications',
+      NOTIFICATION_INBOX_EMPTY_TITLE: 'No notifications yet',
+      NOTIFICATION_INBOX_EMPTY_SUBTITLE:
+        'Recent alerts will appear here after they are received on this device.',
+      NOTIFICATION_INBOX_MARK_ALL_READ: 'Mark all read',
+      NOTIFICATION_INBOX_ALL: 'All',
+      NOTIFICATION_INBOX_UNREAD: 'Unread',
+      NOTIFICATION_INBOX_CATEGORY_CARD: 'Card',
+      NOTIFICATION_INBOX_CATEGORY_SECURITY: 'Security',
+      NOTIFICATION_INBOX_CATEGORY_REWARDS: 'Rewards',
+      NOTIFICATION_INBOX_CATEGORY_BRIDGE_SWAP: 'Bridge/Swap',
+      NOTIFICATION_INBOX_CATEGORY_QUICK_ACTION: 'Quick Actions',
+      NOTIFICATION_INBOX_CATEGORY_GENERAL: 'General',
+      NOTIFICATION_INBOX_OPEN: 'Open',
+      NOTIFICATION_INBOX_REVIEW: 'Review',
+      NOTIFICATION_INBOX_TAKE_ACTION: 'Take action',
+      NOTIFICATION_INBOX_VIEW_DETAILS: 'View details',
       LETS_CONNECT_MSG: "Let's connect to Cypher wallet",
       LETS_CONNECT_SUB_MSG:
         'Create or import wallet to keep your crypto securely',

--- a/src/notification/__tests__/notificationInbox.test.ts
+++ b/src/notification/__tests__/notificationInbox.test.ts
@@ -1,0 +1,386 @@
+/* eslint-disable import/first */
+jest.mock('../../constants/server', () => ({
+  CHAIN_NAMES: ['ethereum', 'cosmos', 'osmosis', 'noble', 'solana'],
+  NotificationEvents: {
+    ACTIVITY_UPDATE: 'ACTIVITY_UPDATE',
+    ADDRESS_ACTIVITY_WEBHOOK: 'ADDRESS_ACTIVITY_WEBHOOK',
+    CARD_APPLICATION_UPDATE: 'CARD_APPLICATION_UPDATE',
+    CARD_TXN_UPDATE: 'CARD_TXN_UPDATE',
+    DAPP_BROWSER_OPEN: 'DAPP_BROWSER_OPEN',
+    THREE_DS_APPROVE: 'THREE_DS_APPROVE',
+  },
+}));
+
+jest.mock('../../constants/data', () => ({
+  QUICK_ACTION_NOTIFICATION_CATEGORY_IDS: ['I4G', 'R4'],
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
+import { screenTitle } from '../../constants';
+import { NOTIFE_ACTIONS, ON_OPEN_NAVIGATE } from '../../constants/enum';
+import {
+  clearAllNotificationInboxScopes,
+  clearNotificationInbox,
+  deleteNotificationInboxItem,
+  getNotificationInboxItems,
+  getNotificationInboxScope,
+  markAllNotificationInboxItemsRead,
+  markNotificationInboxItemRead,
+  MAX_NOTIFICATION_INBOX_ITEMS,
+  normalizeNotificationInboxItem,
+  routeNotificationInboxItem,
+  sanitizeNotificationInboxData,
+  saveNotificationInboxItem,
+} from '../notificationInbox';
+
+const storage = new Map<string, string>();
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe('notificationInbox', () => {
+  beforeEach(() => {
+    storage.clear();
+    jest.clearAllMocks();
+
+    mockAsyncStorage.getItem.mockImplementation(async key => storage.get(key) ?? null);
+    mockAsyncStorage.setItem.mockImplementation(async (key, value) => {
+      storage.set(key, value);
+    });
+    mockAsyncStorage.removeItem.mockImplementation(async key => {
+      storage.delete(key);
+    });
+    mockAsyncStorage.getAllKeys.mockImplementation(async () => Array.from(storage.keys()));
+  });
+
+  it('sanitizes allow-listed payload fields and excludes sensitive/raw fields', () => {
+    const sanitized = sanitizeNotificationInboxData({
+      notificationId: 'n-1',
+      messageId: 'm-1',
+      approveUrl: 'https://approve.example',
+      declineUrl: 'https://decline.example',
+      last4: '1234',
+      transactionAmount: '$10',
+      cardId: 'card-1',
+      provider: 'rain',
+      deliveryId: 'cio-1',
+    });
+
+    expect(sanitized).toEqual({
+      notificationId: 'n-1',
+      messageId: 'm-1',
+      cardId: 'card-1',
+      provider: 'rain',
+      deliveryId: 'cio-1',
+    });
+  });
+
+  it('normalizes Firebase-shaped payloads with title/body fallback and derives safe actions', () => {
+    const item = normalizeNotificationInboxItem(
+      {
+        messageId: 'remote-1',
+        data: {
+          notificationTitle: 'Open dapp',
+          notificationBody: 'Tap to continue',
+          actionKey: 'DAPP_BROWSER_OPEN',
+          url: 'https://example.com',
+          approveUrl: 'https://sensitive.example',
+        },
+      },
+      { source: 'firebase-foreground', scopeId: '0xABC', receivedAt: 10 },
+    );
+
+    expect(item).toMatchObject({
+      title: 'Open dapp',
+      body: 'Tap to continue',
+      status: 'unread',
+      source: 'firebase-foreground',
+      scopeId: '0xabc',
+      action: {
+        type: 'navigate',
+        tab: screenTitle.OPTIONS,
+        screen: screenTitle.BROWSER,
+        params: { url: 'https://example.com' },
+      },
+    });
+    expect(item?.dedupeKey).toBe('notification:remote-1');
+  });
+
+  it('treats 3DS approval inbox records as security information only', () => {
+    const item = normalizeNotificationInboxItem(
+      {
+        notification: { title: '3D Secure', body: 'Approve payment' },
+        data: {
+          actionKey: 'THREE_DS_APPROVE',
+          approveUrl: 'https://approve.example',
+          declineUrl: 'https://decline.example',
+        },
+      },
+      { source: 'notifee-open', receivedAt: 20 },
+    );
+
+    expect(item?.category).toBe('security');
+    expect(item?.action).toEqual({ type: 'none' });
+  });
+
+  it('routes INT_COUNTRY declines to card controls country selection', () => {
+    const item = normalizeNotificationInboxItem(
+      {
+        notification: { title: 'Declined', body: 'Add country to continue' },
+        data: {
+          actionKey: 'CARD_TXN_UPDATE',
+          declineCode: 'I4G',
+          categoryId: 'I4G',
+          cardId: 'card-1',
+          provider: 'rain',
+        },
+      },
+      { source: 'notifee-display', receivedAt: 30 },
+    );
+
+    expect(item?.category).toBe('quickAction');
+    expect(item?.action).toEqual({
+      type: 'navigate',
+      tab: screenTitle.CARD,
+      screen: screenTitle.CARD_CONTROLS,
+      params: {
+        cardId: 'card-1',
+        currentCardProvider: 'rain',
+        onOpenNavigate: ON_OPEN_NAVIGATE.SELECT_COUNTRY,
+      },
+    });
+  });
+
+  it('prefers card transaction URLs for non-decline updates even when card identifiers exist', () => {
+    const item = normalizeNotificationInboxItem(
+      {
+        notification: { title: 'Card transaction', body: 'View details' },
+        data: {
+          actionKey: 'CARD_TXN_UPDATE',
+          cardId: 'card-1',
+          provider: 'rain',
+          url: 'https://card.example/txn',
+        },
+      },
+      { source: 'notifee-display', receivedAt: 31 },
+    );
+
+    expect(item?.action).toEqual({
+      type: 'navigate',
+      tab: screenTitle.CARD,
+      screen: screenTitle.DEBIT_CARD_SCREEN,
+      params: { url: 'https://card.example/txn' },
+    });
+  });
+
+  it('keeps other card decline quick actions on the existing Notifee action path', () => {
+    const item = normalizeNotificationInboxItem(
+      {
+        notification: { title: 'Declined', body: 'Activate card' },
+        data: {
+          actionKey: 'CARD_TXN_UPDATE',
+          declineCode: 'R4',
+          categoryId: 'R4',
+          cardId: 'card-1',
+          provider: 'rain',
+        },
+      },
+      { source: 'notifee-display', receivedAt: 32 },
+    );
+
+    expect(item?.action).toEqual({
+      type: 'quickAction',
+      actionId: NOTIFE_ACTIONS.ACTIVATE_CARD,
+      params: {
+        cardId: 'card-1',
+        provider: 'rain',
+        categoryId: 'R4',
+      },
+    });
+  });
+
+  it('derives actions from legacy data.title event keys', () => {
+    const item = normalizeNotificationInboxItem(
+      {
+        notification: { title: 'Activity update', body: 'Review activity' },
+        data: {
+          title: 'ACTIVITY_UPDATE',
+        },
+      },
+      { source: 'firebase-background', receivedAt: 35 },
+    );
+
+    expect(item?.action).toEqual({
+      type: 'navigate',
+      tab: screenTitle.OPTIONS,
+      screen: screenTitle.ACTIVITIES,
+    });
+  });
+
+  it('selects a canonical wallet scope independent of selected chain', () => {
+    const walletState = {
+      wallet: {
+        solana: { currentIndex: 0, wallets: [{ address: 'SoL', publicKey: 'pk' }] },
+        ethereum: { currentIndex: 0, wallets: [{ address: '0xABC', publicKey: 'pk' }] },
+      },
+      selectedChain: { chainName: 'solana' },
+    // Scope helper only reads wallet chain addresses; the remaining HDWallet fields are irrelevant here.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const scope = getNotificationInboxScope(walletState);
+
+    expect(scope).toBe('0xabc');
+  });
+
+  it('serializes concurrent saves, dedupes by stable ids, and preserves read status', async () => {
+    const first = await saveNotificationInboxItem(
+      { messageId: 'same', notification: { title: 'First', body: 'Body' } },
+      { source: 'seeded-test', scopeId: '0xabc', receivedAt: 1 },
+    );
+    await markNotificationInboxItemRead(first?.id ?? '', { scopeId: '0xabc' });
+
+    await Promise.all([
+      saveNotificationInboxItem(
+        { messageId: 'same', notification: { title: 'Updated', body: 'Body' } },
+        { source: 'seeded-test', scopeId: '0xabc', receivedAt: 2 },
+      ),
+      saveNotificationInboxItem(
+        { messageId: 'other', notification: { title: 'Other', body: 'Body' } },
+        { source: 'seeded-test', scopeId: '0xabc', receivedAt: 3 },
+      ),
+    ]);
+
+    const items = await getNotificationInboxItems({ scopeId: '0xabc' });
+    expect(items).toHaveLength(2);
+    expect(items.find(item => item.dedupeKey === 'notification:same')).toMatchObject({
+      title: 'Updated',
+      status: 'read',
+      receivedAt: 1,
+    });
+  });
+
+  it('dedupes foreground capture and displayed Notifee archive by remote message id in the same scope', async () => {
+    await saveNotificationInboxItem(
+      {
+        messageId: 'remote-foreground-1',
+        notification: { title: 'Foreground', body: 'Body' },
+      },
+      { source: 'firebase-foreground', scopeId: '0xabc', receivedAt: 1 },
+    );
+
+    await saveNotificationInboxItem(
+      {
+        messageId: 'remote-foreground-1',
+        notification: { title: 'Displayed', body: 'Body' },
+        data: { messageId: 'remote-foreground-1' },
+      },
+      { source: 'notifee-display', scopeId: '0xabc', receivedAt: 2 },
+    );
+
+    const items = await getNotificationInboxItems({ scopeId: '0xabc' });
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      dedupeKey: 'notification:remote-foreground-1',
+      title: 'Displayed',
+      receivedAt: 1,
+    });
+  });
+
+  it('caps storage, supports read/delete/clear helpers, and routes navigate actions', async () => {
+    await Promise.all(
+      Array.from({ length: MAX_NOTIFICATION_INBOX_ITEMS + 1 }, async (_, index) =>
+        await saveNotificationInboxItem(
+          {
+            messageId: `msg-${index}`,
+            notification: { title: `Title ${index}`, body: 'Body' },
+            data: { screenToNavigate: screenTitle.ENTER_AMOUNT, chain: 'ETH' },
+          },
+          { source: 'seeded-test', scopeId: '0xabc', receivedAt: index + 1 },
+        ),
+      ),
+    );
+
+    let items = await getNotificationInboxItems({ scopeId: '0xabc' });
+    expect(items).toHaveLength(MAX_NOTIFICATION_INBOX_ITEMS);
+    expect(items[0].title).toBe(`Title ${MAX_NOTIFICATION_INBOX_ITEMS}`);
+
+    await markAllNotificationInboxItemsRead({ scopeId: '0xabc' });
+    items = await getNotificationInboxItems({ scopeId: '0xabc' });
+    expect(items.every(item => item.status === 'read')).toBe(true);
+
+    const navigate = jest.fn();
+    routeNotificationInboxItem(items[0], navigate);
+    expect(navigate).toHaveBeenCalledWith(screenTitle.PORTFOLIO, {
+      screen: screenTitle.ENTER_AMOUNT,
+      params: { chain: 'ETH' },
+    });
+
+    await deleteNotificationInboxItem(items[0].id, { scopeId: '0xabc' });
+    expect(await getNotificationInboxItems({ scopeId: '0xabc' })).toHaveLength(99);
+
+    await clearNotificationInbox({ scopeId: '0xabc' });
+    expect(await getNotificationInboxItems({ scopeId: '0xabc' })).toEqual([]);
+  });
+
+  it('normalizes Notifee-shaped payload ids and derives reward/security/bridge categories', () => {
+    const notifeeItem = normalizeNotificationInboxItem(
+      {
+        id: 'notifee-1',
+        notification: { title: 'Merchant reward', body: 'You earned rewards' },
+        data: { screenToNavigate: screenTitle.MERCHANT_REWARD_LIST },
+      },
+      { source: 'notifee-open', receivedAt: 40 },
+    );
+    const securityItem = normalizeNotificationInboxItem(
+      {
+        notification: { title: 'Security alert', body: 'MFA required' },
+      },
+      { source: 'firebase-background', receivedAt: 41 },
+    );
+    const bridgeItem = normalizeNotificationInboxItem(
+      {
+        notification: { title: 'Swap complete', body: 'Bridge transaction completed' },
+        data: { screenToNavigate: screenTitle.BRIDGE_STATUS },
+      },
+      { source: 'notifee-display', receivedAt: 42 },
+    );
+
+    expect(notifeeItem).toMatchObject({
+      dedupeKey: 'notification:notifee-1',
+      category: 'rewards',
+    });
+    expect(securityItem?.category).toBe('security');
+    expect(bridgeItem?.category).toBe('bridgeSwap');
+  });
+
+  it('uses device scope fallback when no wallet scope is available and clears all inbox scopes', async () => {
+    await saveNotificationInboxItem(
+      { messageId: 'device-msg', notification: { title: 'Device', body: 'Body' } },
+      { source: 'seeded-test', receivedAt: 1 },
+    );
+    await saveNotificationInboxItem(
+      { messageId: 'wallet-msg', notification: { title: 'Wallet', body: 'Body' } },
+      { source: 'seeded-test', scopeId: '0xabc', receivedAt: 2 },
+    );
+
+    expect(await getNotificationInboxItems()).toMatchObject([
+      { title: 'Device', scopeId: 'device' },
+    ]);
+    expect(
+      await getNotificationInboxItems({ scopeId: '0xabc', includeDeviceScope: true }),
+    ).toHaveLength(2);
+
+    await clearAllNotificationInboxScopes();
+
+    expect(storage.has('notificationInbox.v1:device')).toBe(false);
+    expect(storage.has('notificationInbox.v1:0xabc')).toBe(false);
+  });
+
+  it('falls back to an empty list and reports malformed storage', async () => {
+    storage.set('notificationInbox.v1:0xabc', '{bad json');
+
+    await expect(getNotificationInboxItems({ scopeId: '0xabc' })).resolves.toEqual([]);
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/src/notification/__tests__/pushNotification.test.ts
+++ b/src/notification/__tests__/pushNotification.test.ts
@@ -1,0 +1,210 @@
+/* eslint-disable import/first */
+const mockCreateChannel = jest.fn(async () => 'default-channel');
+const mockDisplayNotification = jest.fn(async () => undefined);
+const mockCancelNotification = jest.fn(async () => undefined);
+const mockRequestPermission = jest.fn(async () => undefined);
+const mockSetNotificationCategories = jest.fn(async () => undefined);
+
+jest.mock('@notifee/react-native', () => ({
+  __esModule: true,
+  default: {
+    createChannel: mockCreateChannel,
+    displayNotification: mockDisplayNotification,
+    cancelNotification: mockCancelNotification,
+    requestPermission: mockRequestPermission,
+    setNotificationCategories: mockSetNotificationCategories,
+  },
+  AndroidImportance: { HIGH: 'HIGH' },
+  AndroidStyle: { BIGTEXT: 'BIGTEXT' },
+}));
+
+jest.mock('@react-native-firebase/messaging', () => ({
+  AuthorizationStatus: { AUTHORIZED: 1, PROVISIONAL: 2 },
+  getMessaging: jest.fn(() => ({})),
+  getToken: jest.fn(async () => 'fcm-token'),
+  requestPermission: jest.fn(async () => 1),
+}));
+
+jest.mock('../../global', () => ({
+  hostWorker: { getHost: jest.fn(() => 'https://api.example') },
+}));
+
+jest.mock('../../core/Http', () => ({
+  put: jest.fn(async () => ({})),
+}));
+
+jest.mock('../../core/util', () => ({
+  isAddressSet: jest.fn(() => true),
+}));
+
+jest.mock('../../core/asyncStorage', () => ({
+  getConnectionType: jest.fn(async () => 'EVM'),
+}));
+
+jest.mock('../../notification/notificationInbox', () => ({
+  saveNotificationInboxItem: jest.fn(async () => undefined),
+  sanitizeNotificationInboxData: jest.fn(data => ({ sanitized: true, ...data })),
+}));
+
+import notifee from '@notifee/react-native';
+import { screenTitle } from '../../constants';
+import { GlobalModalType, NOTIFE_ACTIONS } from '../../constants/enum';
+import {
+  routeNotificationInboxAction,
+  showNotification,
+} from '../pushNotification';
+import {
+  saveNotificationInboxItem,
+  sanitizeNotificationInboxData,
+} from '../notificationInbox';
+
+describe('pushNotification inbox wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes raw notification data to the inbox save path before displaying through Notifee', async () => {
+    await showNotification(
+      { title: 'Title', body: 'Body' },
+      { notificationId: 'n-1', secret: 'raw' },
+    );
+
+    expect(sanitizeNotificationInboxData).not.toHaveBeenCalled();
+    expect(saveNotificationInboxItem).toHaveBeenCalledWith(
+      {
+        notification: { title: 'Title', body: 'Body' },
+        data: { notificationId: 'n-1', secret: 'raw' },
+      },
+      { source: 'notifee-display' },
+    );
+    expect(mockDisplayNotification).toHaveBeenCalledTimes(1);
+    expect(
+      (saveNotificationInboxItem as jest.Mock).mock.invocationCallOrder[0],
+    ).toBeLessThan(mockDisplayNotification.mock.invocationCallOrder[0]);
+  });
+
+  it('preserves remote message ids and wallet scope when archiving displayed notifications', async () => {
+    await showNotification(
+      { title: 'Title', body: 'Body' },
+      { notificationId: 'n-1' },
+      { messageId: 'remote-message-1', scopeId: '0xabc' },
+    );
+
+    expect(sanitizeNotificationInboxData).not.toHaveBeenCalled();
+    expect(saveNotificationInboxItem).toHaveBeenCalledWith(
+      {
+        messageId: 'remote-message-1',
+        notification: { title: 'Title', body: 'Body' },
+        data: {
+          notificationId: 'n-1',
+          messageId: 'remote-message-1',
+        },
+      },
+      { source: 'notifee-display', scopeId: '0xabc' },
+    );
+  });
+
+  it('does not display or archive when the existing display path has no body', async () => {
+    await showNotification({ title: 'Title' }, { notificationId: 'n-1' });
+
+    expect(saveNotificationInboxItem).not.toHaveBeenCalled();
+    expect(mockDisplayNotification).not.toHaveBeenCalled();
+  });
+
+  it('routes inbox navigate actions without invoking Notifee cancellation', async () => {
+    const navigation = { navigate: jest.fn() } as any;
+
+    await routeNotificationInboxAction({
+      item: {
+        id: 'inbox-id',
+        dedupeKey: 'dedupe',
+        title: 'Open',
+        body: 'Details',
+        category: 'general',
+        status: 'read',
+        receivedAt: 1,
+        lastUpdatedAt: 1,
+        source: 'seeded-test',
+        scopeId: 'device',
+        action: {
+          type: 'navigate',
+          tab: screenTitle.OPTIONS,
+          screen: screenTitle.BROWSER,
+          params: { url: 'https://example.com' },
+        },
+      },
+      navigation,
+      showModal: jest.fn(),
+      hideModal: jest.fn(),
+    });
+
+    expect(navigation.navigate).toHaveBeenCalledWith(screenTitle.OPTIONS, {
+      screen: screenTitle.BROWSER,
+      params: { url: 'https://example.com' },
+    });
+    expect(notifee.cancelNotification).not.toHaveBeenCalled();
+  });
+
+  it('runs quick actions without passing synthetic inbox ids to Notifee cancellation', async () => {
+    const showModal = jest.fn();
+
+    await routeNotificationInboxAction({
+      item: {
+        id: 'synthetic-inbox-id',
+        dedupeKey: 'dedupe',
+        title: 'Action',
+        body: 'Add country',
+        category: 'quickAction',
+        status: 'read',
+        receivedAt: 1,
+        lastUpdatedAt: 1,
+        source: 'seeded-test',
+        scopeId: 'device',
+        action: {
+          type: 'quickAction',
+          actionId: NOTIFE_ACTIONS.ADD_COUNTRY,
+          params: { cardId: 'card-1', provider: 'rain' },
+        },
+      },
+      navigation: { navigate: jest.fn() } as any,
+      showModal,
+      hideModal: jest.fn(),
+    });
+
+    expect(showModal).toHaveBeenCalledWith(
+      GlobalModalType.CARD_ACTIONS_FROM_NOTIFICATION,
+      expect.objectContaining({
+        data: expect.objectContaining({ cardId: 'card-1', provider: 'rain' }),
+      }),
+    );
+    expect(notifee.cancelNotification).not.toHaveBeenCalled();
+  });
+
+  it('keeps informational inbox actions read-only', async () => {
+    const navigation = { navigate: jest.fn() } as any;
+    const showModal = jest.fn();
+
+    await routeNotificationInboxAction({
+      item: {
+        id: 'three-ds-info',
+        dedupeKey: 'dedupe',
+        title: '3DS',
+        body: 'Review only',
+        category: 'security',
+        status: 'read',
+        receivedAt: 1,
+        lastUpdatedAt: 1,
+        source: 'seeded-test',
+        scopeId: 'device',
+        action: { type: 'none' },
+      },
+      navigation,
+      showModal,
+      hideModal: jest.fn(),
+    });
+
+    expect(navigation.navigate).not.toHaveBeenCalled();
+    expect(showModal).not.toHaveBeenCalled();
+    expect(notifee.cancelNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/notification/notificationInbox.ts
+++ b/src/notification/notificationInbox.ts
@@ -1,0 +1,860 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
+import { screenTitle } from '../constants';
+import { QUICK_ACTION_NOTIFICATION_CATEGORY_IDS } from '../constants/data';
+import {
+  CypherDeclineCodes,
+  NOTIFE_ACTIONS,
+  ON_OPEN_NAVIGATE,
+  RPCODES,
+} from '../constants/enum';
+import { NotificationEvents } from '../constants/server';
+import type { HDWallet } from '../reducers/hdwallet_reducer';
+
+export type NotificationInboxCategory =
+  | 'card'
+  | 'security'
+  | 'rewards'
+  | 'bridgeSwap'
+  | 'quickAction'
+  | 'general';
+
+export type NotificationInboxStatus = 'unread' | 'read';
+
+export type NotificationInboxSource =
+  | 'firebase-foreground'
+  | 'firebase-background'
+  | 'notifee-display'
+  | 'notifee-open'
+  | 'notifee-action'
+  | 'notifee-dismiss'
+  | 'customerio'
+  | 'seeded-test';
+
+export type NotificationInboxAction =
+  | {
+      type: 'navigate';
+      tab: string;
+      screen: string;
+      params?: Record<string, string | number | boolean>;
+    }
+  | {
+      type: 'quickAction';
+      actionId: string;
+      params?: Record<string, string | number | boolean>;
+    }
+  | { type: 'none' };
+
+export interface NotificationInboxItem {
+  id: string;
+  dedupeKey: string;
+  title: string;
+  body: string;
+  category: NotificationInboxCategory;
+  status: NotificationInboxStatus;
+  receivedAt: number;
+  lastUpdatedAt: number;
+  source: NotificationInboxSource;
+  scopeId: string;
+  action: NotificationInboxAction;
+}
+
+export interface NotificationInboxNormalizeOptions {
+  source: NotificationInboxSource;
+  scopeId?: string;
+  receivedAt?: number;
+  markRead?: boolean;
+}
+
+export interface NotificationInboxStorageOptions {
+  scopeId?: string;
+  includeDeviceScope?: boolean;
+}
+
+export type NotificationInboxRouteHandler = (
+  tab: string,
+  route: { screen: string; params?: Record<string, string | number | boolean> },
+) => void;
+
+export const MAX_NOTIFICATION_INBOX_ITEMS = 100;
+export const NOTIFICATION_INBOX_STORAGE_PREFIX = 'notificationInbox.v1:';
+export const NOTIFICATION_INBOX_DEVICE_SCOPE = 'device';
+
+const PREFERRED_SCOPE_CHAINS = ['ethereum', 'solana', 'cosmos', 'osmosis'];
+
+const ALLOWED_DATA_FIELDS = [
+  'notificationId',
+  'messageId',
+  'title',
+  'categoryId',
+  'notificationType',
+  'screenToNavigate',
+  'url',
+  'txnId',
+  'cardId',
+  'provider',
+  'declineCode',
+  'actionKey',
+  'merchantName',
+  'amount',
+  'currency',
+  'chain',
+  'token',
+  'deliveryId',
+  'delivery_id',
+  'cioDeliveryId',
+  'cio_delivery_id',
+  'messageDeliveryId',
+  'deliveryToken',
+  'CIO-Delivery-ID',
+] as const;
+
+const CUSTOMER_IO_DELIVERY_ID_FIELDS = [
+  'deliveryId',
+  'delivery_id',
+  'cioDeliveryId',
+  'cio_delivery_id',
+  'messageDeliveryId',
+  'deliveryToken',
+  'CIO-Delivery-ID',
+] as const;
+
+const QUICK_ACTION_BY_CATEGORY_ID: Record<string, NOTIFE_ACTIONS> = {
+  [CypherDeclineCodes.INT_COUNTRY]: NOTIFE_ACTIONS.ADD_COUNTRY,
+  [CypherDeclineCodes.DAILY_LIMIT]: NOTIFE_ACTIONS.INCREASE_DAILY_LIMIT,
+  [CypherDeclineCodes.MONTHLY_LIMIT]: NOTIFE_ACTIONS.INCREASE_MONTHLY_LIMIT,
+  [RPCODES.CardIsNotActivated]: NOTIFE_ACTIONS.ACTIVATE_CARD,
+  [RPCODES.CardIsBlocked]: NOTIFE_ACTIONS.UNBLOCK_CARD,
+};
+
+const SCREEN_TO_TAB: Record<string, string> = {
+  [screenTitle.ENTER_REFERRAL_CODE]: screenTitle.CARD,
+  [screenTitle.TELEGRAM_PIN_SETUP]: screenTitle.CARD,
+  [screenTitle.TELEGRAM_SETUP]: screenTitle.CARD,
+  [screenTitle.CARD_CONTROLS]: screenTitle.CARD,
+  [screenTitle.DEBIT_CARD_SCREEN]: screenTitle.CARD,
+  [screenTitle.MERCHANT_REWARD_LIST]: screenTitle.CARD,
+  [screenTitle.PREMIUM_SCREEN]: screenTitle.CARD,
+  [screenTitle.ENTER_AMOUNT]: screenTitle.PORTFOLIO,
+  [screenTitle.NOTIFICATION_INBOX]: screenTitle.PORTFOLIO,
+  [screenTitle.CYPHER_AGENT_SCREEN]: screenTitle.CYPHER_AGENT,
+};
+
+const storageQueues = new Map<string, Promise<unknown>>();
+
+type SanitizedNotificationData = Partial<
+  Record<(typeof ALLOWED_DATA_FIELDS)[number], string | number | boolean>
+>;
+
+export interface NotificationInboxInput {
+  id?: string;
+  data?: Record<string, unknown>;
+  notification?: {
+    title?: string;
+    body?: string;
+  };
+  title?: string;
+  body?: string;
+  messageId?: string;
+}
+
+const normalizeScopeId = (scopeId?: string) => {
+  const normalizedScopeId = scopeId?.trim()?.toLowerCase();
+  if (normalizedScopeId) {
+    return normalizedScopeId;
+  }
+  return NOTIFICATION_INBOX_DEVICE_SCOPE;
+};
+
+const storageKeyForScope = (scopeId?: string) =>
+  `${NOTIFICATION_INBOX_STORAGE_PREFIX}${normalizeScopeId(scopeId)}`;
+
+const captureInboxError = (error: unknown) => {
+  Sentry.captureException(error);
+};
+
+const isPersistablePrimitive = (
+  value: unknown,
+): value is string | number | boolean =>
+  typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+
+const toStringValue = (value: unknown) =>
+  isPersistablePrimitive(value) ? String(value) : undefined;
+
+const sanitizeParams = (params: Record<string, unknown>) =>
+  Object.entries(params).reduce<Record<string, string | number | boolean>>(
+    (acc, [key, value]) => {
+      if (isPersistablePrimitive(value) && value !== '') {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {},
+  );
+
+const stableHash = (input: string) => {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (Math.imul(31, hash) + input.charCodeAt(index)) % 2147483647;
+  }
+  return Math.abs(hash).toString(36);
+};
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  return `{${Object.keys(objectValue)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${stableStringify(objectValue[key])}`)
+    .join(',')}}`;
+};
+
+const isNotificationInboxItem = (item: unknown): item is NotificationInboxItem => {
+  const candidate = item as NotificationInboxItem;
+  return (
+    !!candidate &&
+    typeof candidate.id === 'string' &&
+    typeof candidate.dedupeKey === 'string' &&
+    typeof candidate.title === 'string' &&
+    typeof candidate.body === 'string' &&
+    typeof candidate.scopeId === 'string' &&
+    typeof candidate.receivedAt === 'number' &&
+    typeof candidate.lastUpdatedAt === 'number' &&
+    (candidate.status === 'read' || candidate.status === 'unread') &&
+    !!candidate.action
+  );
+};
+
+const readItemsForKey = async (key: string): Promise<NotificationInboxItem[]> => {
+  try {
+    const rawItems = await AsyncStorage.getItem(key);
+    if (!rawItems) {
+      return [];
+    }
+
+    const parsedItems = JSON.parse(rawItems);
+    if (!Array.isArray(parsedItems)) {
+      return [];
+    }
+
+    return parsedItems.filter(isNotificationInboxItem);
+  } catch (error) {
+    captureInboxError(error);
+    return [];
+  }
+};
+
+const writeItemsForKey = async (key: string, items: NotificationInboxItem[]) => {
+  await AsyncStorage.setItem(key, JSON.stringify(items));
+};
+
+const withStorageQueue = async <T>(
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> => {
+  const previous = storageQueues.get(key) ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(operation);
+  const queued = current.catch(() => undefined);
+  storageQueues.set(key, queued);
+
+  try {
+    return await current;
+  } finally {
+    if (storageQueues.get(key) === queued) {
+      storageQueues.delete(key);
+    }
+  }
+};
+
+const getCurrentAddressForChain = (hdWalletState: HDWallet, chain: string) => {
+  const chainWallet = hdWalletState.wallet?.[chain];
+  const directAddress = chainWallet?.address;
+  if (directAddress) {
+    return directAddress;
+  }
+
+  const currentIndex = chainWallet?.currentIndex;
+  if (
+    typeof currentIndex === 'number' &&
+    currentIndex >= 0 &&
+    currentIndex < (chainWallet?.wallets?.length || 0)
+  ) {
+    return chainWallet?.wallets?.[currentIndex]?.address;
+  }
+
+  return undefined;
+};
+
+export const getNotificationInboxScope = (
+  hdWalletState?: HDWallet,
+): string | undefined => {
+  if (!hdWalletState?.wallet) {
+    return undefined;
+  }
+
+  const remainingChains = Object.keys(hdWalletState.wallet).filter(
+    chain => !PREFERRED_SCOPE_CHAINS.includes(chain),
+  );
+  const orderedChains = [...PREFERRED_SCOPE_CHAINS, ...remainingChains];
+
+  for (const chain of orderedChains) {
+    const address = getCurrentAddressForChain(hdWalletState, chain);
+    if (address?.trim()) {
+      return address.trim().toLowerCase();
+    }
+  }
+
+  return undefined;
+};
+
+export const sanitizeNotificationInboxData = (
+  data?: Record<string, unknown> | null,
+): SanitizedNotificationData => {
+  if (!data) {
+    return {};
+  }
+
+  return ALLOWED_DATA_FIELDS.reduce<SanitizedNotificationData>((acc, key) => {
+    const value = data[key];
+    if (isPersistablePrimitive(value)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+};
+
+const getEventKey = (data: SanitizedNotificationData) =>
+  toStringValue(data.actionKey) ??
+  toStringValue(data.notificationType) ??
+  toStringValue(data.title);
+
+const isQuickActionDecline = (data: SanitizedNotificationData) => {
+  const declineCode = toStringValue(data.declineCode);
+  const categoryId = toStringValue(data.categoryId);
+
+  return (
+    (!!declineCode &&
+      QUICK_ACTION_NOTIFICATION_CATEGORY_IDS.includes(
+        declineCode as CypherDeclineCodes | RPCODES,
+      )) ||
+    (!!categoryId && !!QUICK_ACTION_BY_CATEGORY_ID[categoryId])
+  );
+};
+
+const getQuickActionId = (data: SanitizedNotificationData) => {
+  const categoryId = toStringValue(data.categoryId);
+  const declineCode = toStringValue(data.declineCode);
+
+  if (categoryId && QUICK_ACTION_BY_CATEGORY_ID[categoryId]) {
+    return QUICK_ACTION_BY_CATEGORY_ID[categoryId];
+  }
+
+  if (declineCode && QUICK_ACTION_BY_CATEGORY_ID[declineCode]) {
+    return QUICK_ACTION_BY_CATEGORY_ID[declineCode];
+  }
+
+  return undefined;
+};
+
+const textIncludesAny = (text: string, keywords: string[]) =>
+  keywords.some(keyword => text.includes(keyword));
+
+const deriveNotificationInboxCategory = (
+  data: SanitizedNotificationData,
+  title: string,
+  body: string,
+): NotificationInboxCategory => {
+  const eventKey = getEventKey(data);
+  const categoryId = toStringValue(data.categoryId)?.toLowerCase() ?? '';
+  const actionKey = toStringValue(data.actionKey)?.toLowerCase() ?? '';
+  const notificationType =
+    toStringValue(data.notificationType)?.toLowerCase() ?? '';
+  const screenToNavigate = toStringValue(data.screenToNavigate);
+  const searchableText = `${title} ${body} ${categoryId} ${actionKey} ${notificationType}`.toLowerCase();
+
+  if (eventKey === NotificationEvents.THREE_DS_APPROVE) {
+    return 'security';
+  }
+
+  if (eventKey === NotificationEvents.CARD_TXN_UPDATE && isQuickActionDecline(data)) {
+    return 'quickAction';
+  }
+
+  if (
+    eventKey === NotificationEvents.CARD_TXN_UPDATE ||
+    [data.cardId, data.provider, data.declineCode, data.txnId].some(Boolean)
+  ) {
+    return 'card';
+  }
+
+  if (
+    textIncludesAny(searchableText, [
+      'lockdown',
+      'mfa',
+      'auth',
+      'security',
+      'secure',
+      '3ds',
+      '3d secure',
+    ])
+  ) {
+    return 'security';
+  }
+
+  if (
+    screenToNavigate === screenTitle.MERCHANT_REWARD_LIST ||
+    screenToNavigate === screenTitle.REWARDS_SCREEN ||
+    textIncludesAny(searchableText, ['reward', 'rewards', 'referral', 'merchant reward'])
+  ) {
+    return 'rewards';
+  }
+
+  if (
+    screenToNavigate === screenTitle.BRIDGE_STATUS ||
+    screenToNavigate === screenTitle.ENTER_AMOUNT ||
+    textIncludesAny(searchableText, [
+      'bridge',
+      'swap',
+      'load',
+      'fund card',
+      'fund-card',
+      'completed',
+      'complete',
+    ])
+  ) {
+    return 'bridgeSwap';
+  }
+
+  return 'general';
+};
+
+const deriveNotificationInboxAction = (
+  data: SanitizedNotificationData,
+): NotificationInboxAction => {
+  const eventKey = getEventKey(data);
+  const url = toStringValue(data.url);
+  const cardId = toStringValue(data.cardId);
+  const provider = toStringValue(data.provider);
+  const screenToNavigate = toStringValue(data.screenToNavigate);
+
+  switch (eventKey) {
+    case NotificationEvents.DAPP_BROWSER_OPEN:
+      return url
+        ? {
+            type: 'navigate',
+            tab: screenTitle.OPTIONS,
+            screen: screenTitle.BROWSER,
+            params: { url },
+          }
+        : { type: 'none' };
+    case NotificationEvents.ACTIVITY_UPDATE:
+      return {
+        type: 'navigate',
+        tab: screenTitle.OPTIONS,
+        screen: screenTitle.ACTIVITIES,
+      };
+    case NotificationEvents.ADDRESS_ACTIVITY_WEBHOOK:
+      return url
+        ? {
+            type: 'navigate',
+            tab: screenTitle.PORTFOLIO,
+            screen: screenTitle.TRANS_DETAIL,
+            params: { url },
+          }
+        : { type: 'none' };
+    case NotificationEvents.CARD_APPLICATION_UPDATE:
+      return url
+        ? {
+            type: 'navigate',
+            tab: screenTitle.CARD,
+            screen: screenTitle.DEBIT_CARD_SCREEN,
+            params: { url },
+          }
+        : { type: 'none' };
+    case NotificationEvents.CARD_TXN_UPDATE: {
+      const actionId = getQuickActionId(data);
+      const categoryId = toStringValue(data.categoryId) ?? toStringValue(data.declineCode);
+      const isDeclineFlow = !!toStringValue(data.declineCode) || isQuickActionDecline(data);
+
+      if (actionId === NOTIFE_ACTIONS.ADD_COUNTRY && cardId && provider) {
+        return {
+          type: 'navigate',
+          tab: screenTitle.CARD,
+          screen: screenTitle.CARD_CONTROLS,
+          params: {
+            cardId,
+            currentCardProvider: provider,
+            onOpenNavigate: ON_OPEN_NAVIGATE.SELECT_COUNTRY,
+          },
+        };
+      }
+
+      if (actionId && cardId && provider) {
+        return {
+          type: 'quickAction',
+          actionId,
+          params: sanitizeParams({ cardId, provider, categoryId }),
+        };
+      }
+
+      if (url && !isDeclineFlow) {
+        return {
+          type: 'navigate',
+          tab: screenTitle.CARD,
+          screen: screenTitle.DEBIT_CARD_SCREEN,
+          params: { url },
+        };
+      }
+
+      if (cardId && provider) {
+        return {
+          type: 'navigate',
+          tab: screenTitle.CARD,
+          screen: screenTitle.CARD_CONTROLS,
+          params: { cardId, currentCardProvider: provider },
+        };
+      }
+
+      return url
+        ? {
+            type: 'navigate',
+            tab: screenTitle.CARD,
+            screen: screenTitle.DEBIT_CARD_SCREEN,
+            params: { url },
+          }
+        : { type: 'none' };
+    }
+    case NotificationEvents.THREE_DS_APPROVE:
+      return { type: 'none' };
+    default:
+      break;
+  }
+
+  if (screenToNavigate && SCREEN_TO_TAB[screenToNavigate]) {
+    return {
+      type: 'navigate',
+      tab: SCREEN_TO_TAB[screenToNavigate],
+      screen: screenToNavigate,
+      params: sanitizeParams({
+        url,
+        cardId,
+        currentCardProvider: provider,
+        chain: data.chain,
+        token: data.token,
+        txnId: data.txnId,
+      }),
+    };
+  }
+
+  return { type: 'none' };
+};
+
+const getCustomerIODeliveryId = (data: SanitizedNotificationData) => {
+  for (const field of CUSTOMER_IO_DELIVERY_ID_FIELDS) {
+    const deliveryId = toStringValue(data[field]);
+    if (deliveryId) {
+      return deliveryId;
+    }
+  }
+  return undefined;
+};
+
+const getDedupeKey = ({
+  input,
+  data,
+  title,
+  body,
+  category,
+  action,
+}: {
+  input: NotificationInboxInput;
+  data: SanitizedNotificationData;
+  title: string;
+  body: string;
+  category: NotificationInboxCategory;
+  action: NotificationInboxAction;
+}) => {
+  const stableValue = [
+    toStringValue(data.messageId),
+    toStringValue(input.messageId),
+    toStringValue(input.id),
+    toStringValue(data.notificationId),
+    getCustomerIODeliveryId(data),
+    toStringValue(data.txnId),
+    toStringValue(data.url),
+  ].find(Boolean);
+
+  if (stableValue) {
+    return `notification:${stableValue}`;
+  }
+
+  return `fallback:${stableHash(
+    stableStringify({
+      title,
+      body,
+      category,
+      action,
+      cardId: data.cardId,
+      provider: data.provider,
+      declineCode: data.declineCode,
+      categoryId: data.categoryId,
+    }),
+  )}`;
+};
+
+export const normalizeNotificationInboxItem = (
+  input: NotificationInboxInput | undefined | null,
+  options: NotificationInboxNormalizeOptions,
+): NotificationInboxItem | undefined => {
+  if (!input) {
+    return undefined;
+  }
+
+  const sanitizedData = sanitizeNotificationInboxData(input.data);
+  const title =
+    input.notification?.title ??
+    input.title ??
+    toStringValue(input.data?.notificationTitle) ??
+    '';
+  const body =
+    input.notification?.body ??
+    input.body ??
+    toStringValue(input.data?.notificationBody) ??
+    '';
+
+  if (!title && !body) {
+    return undefined;
+  }
+
+  const receivedAt = options.receivedAt ?? Date.now();
+  const category = deriveNotificationInboxCategory(sanitizedData, title, body);
+  const action = deriveNotificationInboxAction(sanitizedData);
+  const scopeId = normalizeScopeId(options.scopeId);
+  const dedupeKey = getDedupeKey({
+    input,
+    data: sanitizedData,
+    title,
+    body,
+    category,
+    action,
+  });
+
+  return {
+    id: `${dedupeKey}:${receivedAt}`,
+    dedupeKey,
+    title,
+    body,
+    category,
+    status: options.markRead ? 'read' : 'unread',
+    receivedAt,
+    lastUpdatedAt: receivedAt,
+    source: options.source,
+    scopeId,
+    action,
+  };
+};
+
+const sortNewestFirst = (items: NotificationInboxItem[]) =>
+  [...items].sort((left, right) => right.receivedAt - left.receivedAt);
+
+export const saveNotificationInboxItem = async (
+  input: NotificationInboxInput | undefined | null,
+  options: NotificationInboxNormalizeOptions,
+): Promise<NotificationInboxItem | undefined> => {
+  const normalizedItem = normalizeNotificationInboxItem(input, options);
+  if (!normalizedItem) {
+    return undefined;
+  }
+
+  const key = storageKeyForScope(normalizedItem.scopeId);
+
+  try {
+    return await withStorageQueue(key, async () => {
+      const items = await readItemsForKey(key);
+      const existingIndex = items.findIndex(
+        item => item.dedupeKey === normalizedItem.dedupeKey,
+      );
+
+      const itemToSave =
+        existingIndex >= 0
+          ? {
+              ...normalizedItem,
+              id: items[existingIndex].id,
+              receivedAt: items[existingIndex].receivedAt,
+              status: options.markRead ? 'read' : items[existingIndex].status,
+              lastUpdatedAt: normalizedItem.lastUpdatedAt,
+            }
+          : normalizedItem;
+
+      const nextItems =
+        existingIndex >= 0
+          ? items.map((item, index) => (index === existingIndex ? itemToSave : item))
+          : [itemToSave, ...items];
+
+      const cappedItems = sortNewestFirst(nextItems).slice(
+        0,
+        MAX_NOTIFICATION_INBOX_ITEMS,
+      );
+      await writeItemsForKey(key, cappedItems);
+      return itemToSave;
+    });
+  } catch (error) {
+    captureInboxError(error);
+    return undefined;
+  }
+};
+
+export const getNotificationInboxItems = async ({
+  scopeId,
+  includeDeviceScope = false,
+}: NotificationInboxStorageOptions = {}): Promise<NotificationInboxItem[]> => {
+  const keys = [storageKeyForScope(scopeId)];
+  if (includeDeviceScope && normalizeScopeId(scopeId) !== NOTIFICATION_INBOX_DEVICE_SCOPE) {
+    keys.push(storageKeyForScope());
+  }
+
+  const itemGroups = await Promise.all(keys.map(readItemsForKey));
+  const byDedupeKey = new Map<string, NotificationInboxItem>();
+
+  for (const item of itemGroups.flat()) {
+    const existingItem = byDedupeKey.get(item.dedupeKey);
+    if (!existingItem || item.lastUpdatedAt > existingItem.lastUpdatedAt) {
+      byDedupeKey.set(item.dedupeKey, item);
+    }
+  }
+
+  return sortNewestFirst(Array.from(byDedupeKey.values()));
+};
+
+export const markNotificationInboxItemRead = async (
+  id: string,
+  { scopeId }: NotificationInboxStorageOptions = {},
+): Promise<NotificationInboxItem | undefined> => {
+  const key = storageKeyForScope(scopeId);
+
+  try {
+    return await withStorageQueue(key, async () => {
+      const items = await readItemsForKey(key);
+      let updatedItem: NotificationInboxItem | undefined;
+      const nextItems = items.map(item => {
+        if (item.id !== id) {
+          return item;
+        }
+        updatedItem = {
+          ...item,
+          status: 'read',
+          lastUpdatedAt: Date.now(),
+        };
+        return updatedItem;
+      });
+
+      if (updatedItem) {
+        await writeItemsForKey(key, nextItems);
+      }
+
+      return updatedItem;
+    });
+  } catch (error) {
+    captureInboxError(error);
+    return undefined;
+  }
+};
+
+export const markAllNotificationInboxItemsRead = async ({
+  scopeId,
+}: NotificationInboxStorageOptions = {}): Promise<NotificationInboxItem[]> => {
+  const key = storageKeyForScope(scopeId);
+
+  try {
+    return await withStorageQueue(key, async () => {
+      const now = Date.now();
+      const items = await readItemsForKey(key);
+      const nextItems = items.map(item => ({
+        ...item,
+        status: 'read' as NotificationInboxStatus,
+        lastUpdatedAt: item.status === 'read' ? item.lastUpdatedAt : now,
+      }));
+      await writeItemsForKey(key, nextItems);
+      return nextItems;
+    });
+  } catch (error) {
+    captureInboxError(error);
+    return [];
+  }
+};
+
+export const deleteNotificationInboxItem = async (
+  id: string,
+  { scopeId }: NotificationInboxStorageOptions = {},
+): Promise<boolean> => {
+  const key = storageKeyForScope(scopeId);
+
+  try {
+    return await withStorageQueue(key, async () => {
+      const items = await readItemsForKey(key);
+      const nextItems = items.filter(item => item.id !== id);
+      if (nextItems.length === items.length) {
+        return false;
+      }
+      await writeItemsForKey(key, nextItems);
+      return true;
+    });
+  } catch (error) {
+    captureInboxError(error);
+    return false;
+  }
+};
+
+export const clearNotificationInbox = async ({
+  scopeId,
+}: NotificationInboxStorageOptions = {}): Promise<void> => {
+  const key = storageKeyForScope(scopeId);
+
+  try {
+    await withStorageQueue(key, async () => {
+      await AsyncStorage.removeItem(key);
+    });
+  } catch (error) {
+    captureInboxError(error);
+  }
+};
+
+export const clearAllNotificationInboxScopes = async (): Promise<void> => {
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const inboxKeys = keys.filter(key =>
+      key.startsWith(NOTIFICATION_INBOX_STORAGE_PREFIX),
+    );
+
+    await Promise.all(
+      inboxKeys.map(async key =>
+        await withStorageQueue(key, async () => {
+          await AsyncStorage.removeItem(key);
+        }),
+      ),
+    );
+  } catch (error) {
+    captureInboxError(error);
+  }
+};
+
+export const routeNotificationInboxItem = (
+  item: NotificationInboxItem,
+  navigate?: NotificationInboxRouteHandler,
+): NotificationInboxAction => {
+  if (item.action.type === 'navigate' && navigate) {
+    navigate(item.action.tab, {
+      screen: item.action.screen,
+      params: item.action.params,
+    });
+  }
+
+  return item.action;
+};

--- a/src/notification/pushNotification.ts
+++ b/src/notification/pushNotification.ts
@@ -25,6 +25,8 @@ import {
 import { screenTitle } from '../constants';
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import { getConnectionType } from '../core/asyncStorage';
+import { saveNotificationInboxItem } from './notificationInbox';
+import type { NotificationInboxItem } from './notificationInbox';
 
 export const getToken = async (address: string) => {
   const ARCH_HOST: string = hostWorker.getHost('ARCH_HOST');
@@ -126,11 +128,29 @@ const getAndroidActions = (categoryId?: CypherDeclineCodes | RPCODES) => {
 export const showNotification = async (
   notification: FirebaseMessagingTypes.Notification | undefined,
   data?: any,
+  inboxOptions: { messageId?: string; scopeId?: string } = {},
 ) => {
   const channelId = await createNotificationChannel();
   const title = notification?.title ?? data?.notificationTitle;
   const body = notification?.body ?? data?.notificationBody;
   if (title && body) {
+    const inboxData =
+      inboxOptions.messageId && !data?.messageId
+        ? { ...data, messageId: inboxOptions.messageId }
+        : data;
+
+    await saveNotificationInboxItem(
+      {
+        ...(inboxOptions.messageId ? { messageId: inboxOptions.messageId } : {}),
+        notification: { title, body },
+        data: inboxData,
+      },
+      {
+        source: 'notifee-display',
+        ...(inboxOptions.scopeId ? { scopeId: inboxOptions.scopeId } : {}),
+      },
+    );
+
     await notifee.displayNotification({
       title,
       body,
@@ -259,6 +279,48 @@ export async function RouteNotificationAction({
 
   if (notificationId) {
     await notifee.cancelNotification(notificationId);
+  }
+}
+
+export async function routeNotificationInboxAction({
+  item,
+  realNotificationId,
+  navigation,
+  showModal,
+  hideModal,
+}: {
+  item: NotificationInboxItem;
+  realNotificationId?: string;
+  navigation: NavigationProp<ParamListBase>;
+  showModal: (type: GlobalModalType, data: any) => void;
+  hideModal: () => void;
+}) {
+  switch (item.action.type) {
+    case 'navigate':
+      navigation?.navigate(item.action.tab, {
+        screen: item.action.screen,
+        params: item.action.params,
+      });
+      break;
+    case 'quickAction':
+      await RouteNotificationAction({
+        // Inbox ids are synthetic local storage ids. Only pass through a real
+        // Notifee notification id when one is available so the helper never
+        // cancels an OS notification using a synthetic inbox id.
+        notificationId: realNotificationId ?? '',
+        actionId: item.action.actionId,
+        data: item.action.params,
+        navigation,
+        showModal,
+        hideModal,
+      });
+      break;
+    case 'none':
+    default:
+      // Informational records, including sanitized 3DS approval inbox entries,
+      // are marked read by callers and intentionally do not replay modals or
+      // notification actions.
+      break;
   }
 }
 

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -70,6 +70,7 @@ import Onmeta from '../containers/FundCardScreen/onmeta';
 import IBC from '../containers/IBC';
 import OpenLegalScreen from '../containers/InfoScreen/openLegalDoc';
 import { NFTHoldingsScreen, NFTOverviewScreen } from '../containers/NFT';
+import NotificationInbox from '../containers/Notifications/NotificationInbox';
 import ManageWallet from '../containers/Options/ManageWallet';
 import NotificationSettings from '../containers/Options/NotificationSettings';
 import PrivateKey from '../containers/Options/PrivateKey';
@@ -241,6 +242,20 @@ export function PortfolioStackScreen() {
         name={screenTitle.PORTFOLIO_SCREEN}
         component={PortfolioScreen}
         options={{ headerShown: false }}
+      />
+
+      <PortfolioStack.Screen
+        name={screenTitle.NOTIFICATION_INBOX}
+        component={NotificationInbox}
+        options={({ navigation }) => ({
+          header: () => (
+            <CustomHeader
+              title={t('NOTIFICATION_INBOX')}
+              navigation={navigation}
+              keyboardHeight={keyboardHeight}
+            />
+          ),
+        })}
       />
 
       <PortfolioStack.Screen

--- a/src/routes/tabStack.tsx
+++ b/src/routes/tabStack.tsx
@@ -285,6 +285,13 @@ const TabStack = React.memo(
             });
             break;
 
+          case screenTitle.NOTIFICATION_INBOX:
+            navigateToScreenInTab(screenTitle.PORTFOLIO, {
+              screen: data.screenToNavigate,
+              params: data.params,
+            });
+            break;
+
           case screenTitle.CYPHER_AGENT_SCREEN:
             navigateToScreenInTab(screenTitle.CYPHER_AGENT, {
               screen: data.screenToNavigate,


### PR DESCRIPTION
## Summary

- Added a local, sanitized notification inbox data layer for Firebase/Notifee/Customer.io JS notification paths with wallet/device scoping, dedupe, serialized AsyncStorage writes, and read/delete/clear helpers.
- Added a Portfolio header bell and Portfolio-stack Notification Inbox screen with category filters, unread/read state, mark-all-read, delete, and safe action routing.
- Wired foreground/background/display/open/action/dismiss notification paths into the inbox and clears inbox records during wallet reset/delete cleanup.

## Notes

- This is intentionally a local JS-path inbox. Native/OS-rendered notifications that never reach JavaScript are outside this v1 capture guarantee.
- Persisted records are sanitized; raw payloads and sensitive 3DS approval/decline URLs are not stored. 3DS inbox entries are informational only.

## Testing

### Unit tests — targeted inbox/push/UI paths (passed)
- **Command:** `npx jest --config jest.config.unit.js src/notification/__tests__/notificationInbox.test.ts src/notification/__tests__/pushNotification.test.ts src/containers/Notifications/__tests__/NotificationInbox.test.tsx --runInBand`
- **Result:** PASS — 3 suites passed, 26 tests passed.

### Unit tests — targeted final Android-testing audit (passed)
- **Command:** `npm run test:unit -- src/notification/__tests__/notificationInbox.test.ts src/notification/__tests__/pushNotification.test.ts src/containers/Notifications/__tests__/NotificationInbox.test.tsx src/core/__tests__/asyncStorage.test.ts --runInBand`
- **Result:** PASS — 4 suites passed, 27 tests passed.
- **Log:** `/code/.generated_artifacts/logs/targeted-unit-tests.log`

### Full unit suite (passed)
- **Command:** `npm run test:unit -- --runInBand`
- **Result:** PASS — 28 suites passed, 796 tests passed.
- **Notes:** Existing Customer.io tests print missing `CUSTOMERIO_CDP_API_KEY` warnings but pass.

### TypeScript check (attempted — failed)
- **Command:** `npx tsc --noEmit`
- **Result:** FAIL.
- **Failure summary:** TypeScript reports styled-component prop typing errors in `src/styles/viewStyle.ts` (e.g. `bGC`, `bC`, `mT`, `dynamicWidthFix` properties not recognized on styled component execution contexts) and one test fixture typing error in `src/utils/__tests__/cardQuote.test.ts`.
- **Log:** `/code/.generated_artifacts/tsc-notification-inbox.log`

### Android/manual validation after WEB3_AUTH_CLIENT_ID was added (attempted — blocked on clean Redroid)
- **Build/install commands:**
  - `npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/`
  - `cd android && JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ANDROID_HOME=/opt/android-sdk ./gradlew assembleDebug --no-daemon`
  - `adb -s localhost:5555 install -r /code/.generated_artifacts/apk/cypherd-notification-inbox-debug.apk`
- **Build/install result:** PASS — clean committed tree built successfully and installed on Redroid.
- **Runtime result:** BLOCKED — the previous missing `WEB3_AUTH_CLIENT_ID` crash is gone, but the clean APK starts React Native and then exits/returns to launcher on Redroid. The app UI, Portfolio, and Notification Inbox were unreachable.
- **Observed blocker evidence:** Logcat shows `Running "Cypherd"`, production ARCH host output, no `WEB3_AUTH_CLIENT_ID env var is not defined` error, then process exit due to signal 9. Redroid root indicators are present and clean Redroid exits are consistent with the app's jailbreak/root detection path.
- **Troubleshooting:** Testing attempted an emulator-only root-hide workaround without source changes (`adb root`, attempted remount, temporary `/system/xbin/su` rename, then restore). The clean APK still exited after splash.
- **Unverified due to blocker:** Portfolio bell visibility, opening Notification Inbox, empty/populated inbox UI, filters, mark-all-read, delete, informational 3DS/none behavior, navigate actions, quick-action safe behavior, and device+wallet scope runtime behavior.
- **Required next step for full visual validation:** Run the clean APK on a non-rooted Android device/emulator, or explicitly authorize a temporary uncommitted root-detection bypass build for UI exploration.

### Android artifacts
- `/code/.generated_artifacts/logs/react-native-bundle.log`
- `/code/.generated_artifacts/logs/gradle-assembleDebug.log`
- `/code/.generated_artifacts/apk/cypherd-notification-inbox-debug.apk`
- `/code/.generated_artifacts/logs/adb-install.log`
- `/code/.generated_artifacts/logs/logcat_after_launch.txt`
- `/code/.generated_artifacts/images/cypherd_launch_after_12s.png`
- `/code/.generated_artifacts/images/cypherd_launch_desktop_after_12s.png`
- `/code/.generated_artifacts/logs/targeted-unit-tests.log`
- `/code/.generated_artifacts/logs/redroid-root-hide-attempt.log`
- `/code/.generated_artifacts/logs/logcat_after_su_hidden_launch.txt`
- `/code/.generated_artifacts/images/cypherd_launch_after_su_hidden.png`
- `/code/.generated_artifacts/recordings/notification_inbox_android_validation.mp4`
- `/code/.generated_artifacts/logs/ui_after_launch.xml`
- `/code/.generated_artifacts/logs/apk-sha256.txt`
- `/code/.generated_artifacts/images/redroid_desktop_ready.png`

## Stash / generated files

- Preserved unrelated pre-existing stash: `stash@{0}: On beta: vorflux-preserve-preexisting-local-changes-before-notification-inbox`.
- Generated Android bundle/resource files created during APK testing were removed from the repo working tree and are not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Notification Inbox accessible from the Portfolio header (bell icon) to view all push notifications
  * Notifications now persist in a dedicated inbox with filtering options by read status and category
  * Users can mark notifications as read individually or in bulk, and delete notifications as needed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CypherD-IO/mobile-app/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->