### PR TITLE
Warn and gate ERC20 drainer scams (approve + permit + blocklist)

### DIFF
--- a/src/components/v2/walletConnectV2Views/SigningModal.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModal.tsx
@@ -48,6 +48,7 @@ import {
   RenderTransactionSignModal,
   RenderTypedTransactionSignModal,
 } from './SigningModals/TxnModals';
+import { RiskAlertFooter } from './SigningModals/RiskAlertFooter';
 import { getGasPriceFor } from '../../../containers/Browser/gasHelper';
 import Button from '../button';
 import { DecimalHelper } from '../../../utils/decimalHelper';
@@ -70,6 +71,9 @@ export default function SigningModal({
   const [acceptingRequest, setAcceptingRequest] = useState(false);
   const [rejectingRequest, setRejectingRequest] = useState(false);
   const [dataIsReady, setDataIsReady] = useState(false);
+  const [riskGateRequired, setRiskGateRequired] = useState(false);
+  const [riskIgnored, setRiskIgnored] = useState(false);
+  const canConfirm = !riskGateRequired || riskIgnored;
   const [nativeSendTxnData, setNativeSendTxnData] =
     useState<ISendTxnData | null>(null);
   const hdWalletContext = useContext<any>(HdWalletContext);
@@ -92,7 +96,7 @@ export default function SigningModal({
     requestSession,
     dAppInfo: IDAppInfo | undefined,
     chain: Chain | undefined,
-    publicClient: PublicClient;
+    publicClient: PublicClient | undefined;
   const isMessageModalForSigningTypedData =
     modalPayload?.params && 'signMessageTitle' in modalPayload.params;
 
@@ -590,6 +594,8 @@ export default function SigningModal({
                     method={method}
                     data={decodedABIData}
                     nativeSendTxnData={nativeSendTxnData}
+                    publicClient={publicClient}
+                    onRiskAssessed={setRiskGateRequired}
                   />
                 ) : (
                   <Loader />
@@ -616,9 +622,11 @@ export default function SigningModal({
             <CyDView className={'w-full px-[25px] mt-[12px] mb-[24px]'}>
               <Button
                 loading={acceptingRequest}
+                disabled={!canConfirm}
                 style='p-[3%] mt-[12px]'
                 title={renderAcceptTitle(method)}
                 onPress={() => {
+                  if (!canConfirm) return;
                   void handleAccept();
                   void intercomAnalyticsLog('signModal_accept_click');
                 }}
@@ -634,6 +642,9 @@ export default function SigningModal({
                 }}
               />
             </CyDView>
+            {riskGateRequired && !riskIgnored ? (
+              <RiskAlertFooter onIgnoreAll={() => setRiskIgnored(true)} />
+            ) : null}
           </CyDView>
         ) : (
           <Loader />

--- a/src/components/v2/walletConnectV2Views/SigningModal.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModal.tsx
@@ -650,7 +650,6 @@ export default function SigningModal({
                 style='p-[3%] mt-[12px]'
                 title={renderAcceptTitle(method)}
                 onPress={() => {
-                  if (!canConfirm) return;
                   void handleAccept();
                   void intercomAnalyticsLog('signModal_accept_click');
                 }}

--- a/src/components/v2/walletConnectV2Views/SigningModal.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModal.tsx
@@ -49,6 +49,8 @@ import {
   RenderTypedTransactionSignModal,
 } from './SigningModals/TxnModals';
 import { RiskAlertFooter } from './SigningModals/RiskAlertFooter';
+import { RenderPermitSignModal } from './SigningModals/PermitSignModal';
+import { parsePermitTypedData } from '../../../utils/permitParser';
 import { getGasPriceFor } from '../../../containers/Browser/gasHelper';
 import Button from '../button';
 import { DecimalHelper } from '../../../utils/decimalHelper';
@@ -603,21 +605,43 @@ export default function SigningModal({
               {(method === EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA ||
                 method === EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3 ||
                 method === EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4) &&
-                (payloadFrom === SigningModalPayloadFrom.WALLETCONNECT ? (
-                  <RenderTypedTransactionSignModal
-                    dAppInfo={dAppInfo}
-                    chain={chain}
-                    method={method}
-                    messageParams={requestParams}
-                  />
-                ) : (
-                  <RenderTypedTransactionSignModal
-                    dAppInfo={dAppInfo}
-                    chain={chain}
-                    method={method}
-                    messageParams={paramsFromPayload}
-                  />
-                ))}
+                (() => {
+                  const activeParams =
+                    payloadFrom === SigningModalPayloadFrom.WALLETCONNECT
+                      ? requestParams
+                      : paramsFromPayload;
+                  const typedDataJson = Array.isArray(activeParams)
+                    ? activeParams[1]
+                    : undefined;
+                  const ownerFromParams = Array.isArray(activeParams)
+                    ? typeof activeParams[0] === 'string'
+                      ? activeParams[0]
+                      : undefined
+                    : undefined;
+                  const permit =
+                    method === EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4
+                      ? parsePermitTypedData(typedDataJson)
+                      : null;
+                  if (permit) {
+                    return (
+                      <RenderPermitSignModal
+                        dAppInfo={dAppInfo}
+                        permit={permit}
+                        publicClient={publicClient}
+                        ownerAddress={ownerFromParams}
+                        onRiskAssessed={setRiskGateRequired}
+                      />
+                    );
+                  }
+                  return (
+                    <RenderTypedTransactionSignModal
+                      dAppInfo={dAppInfo}
+                      chain={chain}
+                      method={method}
+                      messageParams={activeParams}
+                    />
+                  );
+                })()}
             </CyDScrollView>
             <CyDView className={'w-full px-[25px] mt-[12px] mb-[24px]'}>
               <Button

--- a/src/components/v2/walletConnectV2Views/SigningModals/PermitSignModal.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModals/PermitSignModal.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useMemo } from 'react';
+import { t } from 'i18next';
+import type { PublicClient } from 'viem';
+import { formatUnits } from 'viem';
+import {
+  CyDText,
+  CyDView,
+} from '../../../../styles/tailwindComponents';
+import {
+  Divider,
+  RenderDAPPInfo,
+} from './SigningModalComponents';
+import { ScamWarningBanner } from './ScamWarningBanner';
+import { IDAppInfo } from '../../../../models/signingModalData.interface';
+import { NormalizedPermit, PermitItem } from '../../../../utils/permitParser';
+import {
+  PermitItemAssessment,
+  assessPermitRisk,
+  permitBannerCopy,
+} from '../../../../utils/approveGuard';
+import { useTokenBalances } from '../../../../hooks/useTokenBalances';
+import { getMaskedAddress } from '../../../../core/util';
+
+const KIND_LABEL: Record<NormalizedPermit['kind'], string> = {
+  eip2612: 'Off-chain approval (EIP-2612)',
+  'permit2-single': 'Off-chain approval (Permit2)',
+  'permit2-batch': 'Off-chain batch approval (Permit2)',
+};
+
+const noopRiskAssessed = (_required: boolean): void => {
+  // intentional noop
+};
+
+export const RenderPermitSignModal = ({
+  dAppInfo,
+  permit,
+  publicClient,
+  ownerAddress,
+  onRiskAssessed = noopRiskAssessed,
+}: {
+  dAppInfo: IDAppInfo | undefined;
+  permit: NormalizedPermit;
+  publicClient?: PublicClient;
+  ownerAddress?: string;
+  onRiskAssessed?: (required: boolean) => void;
+}) => {
+  const tokenAddresses = useMemo(
+    () => permit.items.map(i => i.token),
+    [permit.items],
+  );
+  const { balances } = useTokenBalances(
+    publicClient,
+    tokenAddresses,
+    ownerAddress,
+  );
+
+  const risk = useMemo(
+    () =>
+      assessPermitRisk(permit, token => balances.get(token.toLowerCase()) ?? null),
+    [permit, balances],
+  );
+
+  const bannerCopy = useMemo(() => permitBannerCopy(risk), [risk]);
+
+  useEffect(() => {
+    onRiskAssessed(risk.requiresHardGate);
+  }, [risk.requiresHardGate, onRiskAssessed]);
+
+  return (
+    <CyDView>
+      {dAppInfo ? <RenderDAPPInfo dAppInfo={dAppInfo} /> : null}
+      {bannerCopy ? (
+        <ScamWarningBanner
+          level={bannerCopy.level}
+          title={t<string>(bannerCopy.titleKey)}
+          message={bannerCopy.message}
+        />
+      ) : null}
+      <CyDView className='my-[10px]'>
+        <CyDText className='text-[14px] font-bold mb-[6px] ml-[4px]'>
+          {KIND_LABEL[permit.kind]}
+        </CyDText>
+        <CyDView className='bg-n40 rounded-[8px] py-[12px] px-[12px]'>
+          {risk.perItem.map((entry, idx) => (
+            <PermitItemRow key={`${entry.item.token}-${idx}`} entry={entry} />
+          ))}
+        </CyDView>
+      </CyDView>
+      <Divider />
+      <CyDView className='my-[10px]'>
+        <CyDView className='bg-n40 rounded-[8px] py-[12px] px-[12px]'>
+          <CyDView className='flex flex-row justify-between'>
+            <CyDText className='text-[14px] font-bold'>
+              {t<string>('SPENDER')}
+            </CyDText>
+            <CyDText className='text-[14px]'>
+              {getMaskedAddress(permit.spender, 10)}
+            </CyDText>
+          </CyDView>
+          {permit.deadline ? (
+            <>
+              <CyDView className='h-[1px] bg-gray-200 mt-[10px] mb-[8px]' />
+              <CyDView className='flex flex-row justify-between'>
+                <CyDText className='text-[14px] font-bold'>
+                  {t<string>('DEADLINE')}
+                </CyDText>
+                <CyDText className='text-[14px]'>
+                  {formatDeadline(permit.deadline)}
+                </CyDText>
+              </CyDView>
+            </>
+          ) : null}
+        </CyDView>
+      </CyDView>
+    </CyDView>
+  );
+};
+
+const PermitItemRow = ({ entry }: { entry: PermitItemAssessment }) => {
+  const { item, isUnlimited, isOverBalance } = entry;
+  return (
+    <CyDView className='py-[8px]'>
+      <CyDView className='flex flex-row justify-between items-center'>
+        <CyDView className='flex-1 pr-[10px]'>
+          <CyDText className='text-[13px] font-bold'>
+            {item.tokenSymbol ?? getMaskedAddress(item.token, 8)}
+          </CyDText>
+          <CyDText className='text-[11px] text-subTextColor mt-[2px]'>
+            {getMaskedAddress(item.token, 8)}
+          </CyDText>
+        </CyDView>
+        <CyDView className='flex flex-col items-end'>
+          <CyDText
+            className={`text-[16px] font-extrabold ${
+              isUnlimited ? 'text-errorTextRed' : ''
+            }`}>
+            {isUnlimited
+              ? `Unlimited ${item.tokenSymbol ?? ''}`.trim()
+              : formatPermitAmount(item)}
+          </CyDText>
+          {item.expiration ? (
+            <CyDText className='text-[11px] text-subTextColor'>
+              {`Expires ${formatDeadline(item.expiration)}`}
+            </CyDText>
+          ) : null}
+          {isOverBalance && !isUnlimited ? (
+            <CyDText className='text-[11px] text-warningTextYellow font-medium mt-[2px]'>
+              {t<string>('PERMIT_AMOUNT_EXCEEDS_BALANCE')}
+            </CyDText>
+          ) : null}
+        </CyDView>
+      </CyDView>
+    </CyDView>
+  );
+};
+
+function formatPermitAmount(item: PermitItem): string {
+  const symbol = item.tokenSymbol ?? '';
+  try {
+    if (item.amount === 0n) return `0 ${symbol}`.trim();
+    const display = formatUnits(item.amount, 18).replace(/\.?0+$/, '');
+    return `${display}${symbol ? ` ${symbol}` : ''} (raw)`;
+  } catch {
+    return `${item.amount.toString()} ${symbol}`.trim();
+  }
+}
+
+function formatDeadline(deadlineUnix: number): string {
+  if (!Number.isFinite(deadlineUnix) || deadlineUnix <= 0) return '—';
+  if (deadlineUnix > 1e12) return new Date(deadlineUnix).toLocaleString();
+  return new Date(deadlineUnix * 1000).toLocaleString();
+}

--- a/src/components/v2/walletConnectV2Views/SigningModals/PermitSignModal.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModals/PermitSignModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { t } from 'i18next';
 import type { PublicClient } from 'viem';
 import { formatUnits } from 'viem';
@@ -20,6 +20,7 @@ import {
 } from '../../../../utils/approveGuard';
 import { useTokenBalances } from '../../../../hooks/useTokenBalances';
 import { getMaskedAddress } from '../../../../core/util';
+import { isAddressScamRemote } from '../../../../core/securityCheck';
 
 const KIND_TITLE_KEY: Record<NormalizedPermit['kind'], string> = {
   eip2612: 'PERMIT_KIND_EIP2612',
@@ -54,10 +55,27 @@ export const RenderPermitSignModal = ({
     ownerAddress,
   );
 
+  // Server-side scam-spender lookup. Defaults to false; updates async if the
+  // arch endpoint reports a hit. Fails open on network error.
+  const [remoteScamSpender, setRemoteScamSpender] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void isAddressScamRemote(permit.spender).then(hit => {
+      if (!cancelled) setRemoteScamSpender(hit);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [permit.spender]);
+
   const risk = useMemo(
     () =>
-      assessPermitRisk(permit, token => balances.get(token.toLowerCase()) ?? null),
-    [permit, balances],
+      assessPermitRisk(
+        permit,
+        token => balances.get(token.toLowerCase()) ?? null,
+        remoteScamSpender,
+      ),
+    [permit, balances, remoteScamSpender],
   );
 
   const bannerCopy = useMemo(() => permitBannerCopy(risk), [risk]);

--- a/src/components/v2/walletConnectV2Views/SigningModals/PermitSignModal.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModals/PermitSignModal.tsx
@@ -21,10 +21,10 @@ import {
 import { useTokenBalances } from '../../../../hooks/useTokenBalances';
 import { getMaskedAddress } from '../../../../core/util';
 
-const KIND_LABEL: Record<NormalizedPermit['kind'], string> = {
-  eip2612: 'Off-chain approval (EIP-2612)',
-  'permit2-single': 'Off-chain approval (Permit2)',
-  'permit2-batch': 'Off-chain batch approval (Permit2)',
+const KIND_TITLE_KEY: Record<NormalizedPermit['kind'], string> = {
+  eip2612: 'PERMIT_KIND_EIP2612',
+  'permit2-single': 'PERMIT_KIND_PERMIT2_SINGLE',
+  'permit2-batch': 'PERMIT_KIND_PERMIT2_BATCH',
 };
 
 const noopRiskAssessed = (_required: boolean): void => {
@@ -78,7 +78,7 @@ export const RenderPermitSignModal = ({
       ) : null}
       <CyDView className='my-[10px]'>
         <CyDText className='text-[14px] font-bold mb-[6px] ml-[4px]'>
-          {KIND_LABEL[permit.kind]}
+          {t<string>(KIND_TITLE_KEY[permit.kind])}
         </CyDText>
         <CyDView className='bg-n40 rounded-[8px] py-[12px] px-[12px]'>
           {risk.perItem.map((entry, idx) => (
@@ -135,12 +135,16 @@ const PermitItemRow = ({ entry }: { entry: PermitItemAssessment }) => {
               isUnlimited ? 'text-errorTextRed' : ''
             }`}>
             {isUnlimited
-              ? `Unlimited ${item.tokenSymbol ?? ''}`.trim()
+              ? t<string>('PERMIT_AMOUNT_UNLIMITED', {
+                  symbol: item.tokenSymbol ?? '',
+                }).trim()
               : formatPermitAmount(item)}
           </CyDText>
           {item.expiration ? (
             <CyDText className='text-[11px] text-subTextColor'>
-              {`Expires ${formatDeadline(item.expiration)}`}
+              {t<string>('PERMIT_EXPIRES_AT', {
+                when: formatDeadline(item.expiration),
+              })}
             </CyDText>
           ) : null}
           {isOverBalance && !isUnlimited ? (
@@ -156,13 +160,27 @@ const PermitItemRow = ({ entry }: { entry: PermitItemAssessment }) => {
 
 function formatPermitAmount(item: PermitItem): string {
   const symbol = item.tokenSymbol ?? '';
-  try {
-    if (item.amount === 0n) return `0 ${symbol}`.trim();
-    const display = formatUnits(item.amount, 18).replace(/\.?0+$/, '');
-    return `${display}${symbol ? ` ${symbol}` : ''} (raw)`;
-  } catch {
-    return `${item.amount.toString()} ${symbol}`.trim();
+  if (item.amount === 0n) return `0 ${symbol}`.trim();
+  const hasDecimals =
+    typeof item.decimals === 'number' &&
+    Number.isInteger(item.decimals) &&
+    item.decimals >= 0 &&
+    item.decimals <= 78;
+  if (hasDecimals) {
+    try {
+      const display = formatUnits(item.amount, item.decimals as number).replace(
+        /\.?0+$/,
+        '',
+      );
+      return `${display}${symbol ? ` ${symbol}` : ''}`;
+    } catch {
+      // fall through to raw display
+    }
   }
+  return t<string>('PERMIT_AMOUNT_RAW', {
+    amount: item.amount.toString(),
+    symbol,
+  }).trim();
 }
 
 function formatDeadline(deadlineUnix: number): string {

--- a/src/components/v2/walletConnectV2Views/SigningModals/RiskAlertFooter.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModals/RiskAlertFooter.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { t } from 'i18next';
+import {
+  CyDMaterialDesignIcons,
+  CyDText,
+  CyDTouchView,
+  CyDView,
+} from '../../../../styles/tailwindComponents';
+
+export const RiskAlertFooter = ({
+  onIgnoreAll,
+}: {
+  onIgnoreAll: () => void;
+}) => {
+  return (
+    <CyDView className='mx-[25px] mb-[12px] flex flex-row items-center justify-between rounded-[8px] border-[1px] border-errorTextRed bg-errorRed px-[12px] py-[10px]'>
+      <CyDView className='flex flex-row items-center flex-1 pr-[10px]'>
+        <CyDMaterialDesignIcons
+          name='alert-circle'
+          size={18}
+          className='text-errorTextRed mr-[8px]'
+        />
+        <CyDText className='text-errorTextRed text-[13px] font-medium flex-1'>
+          {t<string>('RISK_FOOTER_MESSAGE')}
+        </CyDText>
+      </CyDView>
+      <CyDTouchView activeOpacity={0.7} onPress={onIgnoreAll}>
+        <CyDText className='text-errorTextRed text-[13px] font-bold underline'>
+          {t<string>('RISK_FOOTER_IGNORE_ALL')}
+        </CyDText>
+      </CyDTouchView>
+    </CyDView>
+  );
+};

--- a/src/components/v2/walletConnectV2Views/SigningModals/ScamWarningBanner.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModals/ScamWarningBanner.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  CyDMaterialDesignIcons,
+  CyDText,
+  CyDView,
+} from '../../../../styles/tailwindComponents';
+import { ApproveRiskLevel } from '../../../../utils/approveGuard';
+
+export const ScamWarningBanner = ({
+  level,
+  title,
+  message,
+}: {
+  level: ApproveRiskLevel;
+  title: string;
+  message: string;
+}) => {
+  if (level === 'none' || !message) return null;
+
+  const isDanger = level === 'danger';
+  const containerClass = isDanger
+    ? 'bg-errorRed border-errorTextRed'
+    : 'bg-warningYellow border-warningTextYellow';
+  const textColor = isDanger ? 'text-errorTextRed' : 'text-warningTextYellow';
+  const iconName = isDanger ? 'alert-octagon' : 'alert';
+
+  return (
+    <CyDView
+      className={`rounded-[10px] my-[10px] px-[12px] py-[10px] border-[1px] ${containerClass}`}>
+      <CyDView className='flex flex-row items-start'>
+        <CyDMaterialDesignIcons
+          name={iconName}
+          size={20}
+          className={`${textColor} mr-[8px] mt-[1px]`}
+        />
+        <CyDView className='flex-1'>
+          <CyDText className={`font-extrabold text-[14px] ${textColor}`}>
+            {title}
+          </CyDText>
+          <CyDText className={`text-[13px] font-medium mt-[2px] ${textColor}`}>
+            {message}
+          </CyDText>
+        </CyDView>
+      </CyDView>
+    </CyDView>
+  );
+};

--- a/src/components/v2/walletConnectV2Views/SigningModals/TxnModals.tsx
+++ b/src/components/v2/walletConnectV2Views/SigningModals/TxnModals.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
+import type { PublicClient } from 'viem';
 import { DecodedResponseTypes } from '../../../../constants/enum';
 import { Chain } from '../../../../constants/server';
 import { intercomAnalyticsLog } from '../../../../containers/utilities/analyticsUtility';
@@ -26,6 +27,17 @@ import {
 import { t } from 'i18next';
 import AppImages from '../../../../../assets/images/appImages';
 import { DecimalHelper } from '../../../../utils/decimalHelper';
+import { ScamWarningBanner } from './ScamWarningBanner';
+import {
+  approveBannerCopy,
+  assessApproveRisk,
+  assessSendRisk,
+  sendBannerCopy,
+} from '../../../../utils/approveGuard';
+import { useTokenBalanceForApprove } from '../../../../hooks/useTokenBalanceForApprove';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noopRiskAssessed = (_required: boolean): void => {};
 
 export const RenderTransactionSignModal = ({
   dAppInfo,
@@ -33,12 +45,16 @@ export const RenderTransactionSignModal = ({
   method,
   data,
   nativeSendTxnData,
+  publicClient,
+  onRiskAssessed = noopRiskAssessed,
 }: {
   dAppInfo: IDAppInfo | undefined;
   chain: Chain;
   method: string;
   data: IExtendedDecodedTxnResponse | null;
   nativeSendTxnData: ISendTxnData | null;
+  publicClient?: PublicClient;
+  onRiskAssessed?: (required: boolean) => void;
 }) => {
   if (!nativeSendTxnData) {
     if (data && 'to' in data) {
@@ -55,6 +71,8 @@ export const RenderTransactionSignModal = ({
     switch (data?.type) {
       case DecodedResponseTypes.SEND: {
         void intercomAnalyticsLog('eth_sendTransaction_SEND');
+        const sendRisk = assessSendRisk(data);
+        const sendCopy = sendBannerCopy(sendRisk);
         if (data?.gasPrice && data.native_token.amount && data.type_send) {
           const gasPriceInWei = DecimalHelper.multiply(
             data?.gasPrice,
@@ -89,19 +107,37 @@ export const RenderTransactionSignModal = ({
             availableBalance,
           };
           return (
-            <RenderSendTransactionSignModal
-              dAppInfo={dAppInfo}
-              sendTxnData={sendTxnData}
-            />
+            <CyDView>
+              {sendCopy ? (
+                <ScamWarningBanner
+                  level={sendCopy.level}
+                  title={t<string>(sendCopy.titleKey)}
+                  message={sendCopy.message}
+                />
+              ) : null}
+              <RenderSendTransactionSignModal
+                dAppInfo={dAppInfo}
+                sendTxnData={sendTxnData}
+              />
+            </CyDView>
           );
         } else {
           return (
-            <RenderDefaultSignModal
-              dAppInfo={dAppInfo}
-              chain={chain}
-              method={method}
-              data={data}
-            />
+            <CyDView>
+              {sendCopy ? (
+                <ScamWarningBanner
+                  level={sendCopy.level}
+                  title={t<string>(sendCopy.titleKey)}
+                  message={sendCopy.message}
+                />
+              ) : null}
+              <RenderDefaultSignModal
+                dAppInfo={dAppInfo}
+                chain={chain}
+                method={method}
+                data={data}
+              />
+            </CyDView>
           );
         }
       }
@@ -125,11 +161,15 @@ export const RenderTransactionSignModal = ({
             approvalTokenLogo: approvalToken.logo_url,
             chainLogo: chain.logo_url,
             amount: {
-              inTokensWithSymbol: `${data.type_token_approval.token_amount} ${data.type_token_approval.token_symbol}`,
-              inUSDWithSymbol: `$${DecimalHelper.multiply(
-                data.type_token_approval.token_amount,
-                approvalToken.price,
-              ).toString()}`,
+              inTokensWithSymbol: data.type_token_approval.is_infinity
+                ? `Unlimited ${data.type_token_approval.token_symbol}`
+                : `${data.type_token_approval.token_amount} ${data.type_token_approval.token_symbol}`,
+              inUSDWithSymbol: data.type_token_approval.is_infinity
+                ? '—'
+                : `$${DecimalHelper.multiply(
+                    data.type_token_approval.token_amount,
+                    approvalToken.price,
+                  ).toString()}`,
             },
             spender: {
               address: getMaskedAddress(data.type_token_approval.spender, 10),
@@ -146,11 +186,17 @@ export const RenderTransactionSignModal = ({
             availableBalance: `${formatAmount(data.native_token.amount)} ${
               data.native_token.symbol
             }`,
+            tokenAddress: approvalToken.id,
+            tokenSymbol: data.type_token_approval.token_symbol,
+            ownerAddress: data.from_addr,
           };
           return (
             <RenderApproveTokenModal
               dAppInfo={dAppInfo}
               approveTokenData={approveTokenData}
+              decoded={data}
+              publicClient={publicClient}
+              onRiskAssessed={onRiskAssessed}
             />
           );
         } else {
@@ -166,6 +212,8 @@ export const RenderTransactionSignModal = ({
       }
       case DecodedResponseTypes.CALL: {
         void intercomAnalyticsLog('eth_sendTransaction_CALL');
+        const callRisk = assessSendRisk(data);
+        const callCopy = sendBannerCopy(callRisk);
         if (data?.gasPrice) {
           const {
             send_token_list: sendTokenList,
@@ -224,29 +272,56 @@ export const RenderTransactionSignModal = ({
               },
             };
             return (
-              <RenderSwapTransactionSignModal
-                dAppInfo={dAppInfo}
-                swapTxnData={swapTxnData}
-              />
+              <CyDView>
+                {callCopy ? (
+                  <ScamWarningBanner
+                    level={callCopy.level}
+                    title={t<string>(callCopy.titleKey)}
+                    message={callCopy.message}
+                  />
+                ) : null}
+                <RenderSwapTransactionSignModal
+                  dAppInfo={dAppInfo}
+                  swapTxnData={swapTxnData}
+                />
+              </CyDView>
             );
           } else {
             return (
+              <CyDView>
+                {callCopy ? (
+                  <ScamWarningBanner
+                    level={callCopy.level}
+                    title={t<string>(callCopy.titleKey)}
+                    message={callCopy.message}
+                  />
+                ) : null}
+                <RenderDefaultSignModal
+                  dAppInfo={dAppInfo}
+                  chain={chain}
+                  method={method}
+                  data={data}
+                />
+              </CyDView>
+            );
+          }
+        } else {
+          return (
+            <CyDView>
+              {callCopy ? (
+                <ScamWarningBanner
+                  level={callCopy.level}
+                  title={t<string>(callCopy.titleKey)}
+                  message={callCopy.message}
+                />
+              ) : null}
               <RenderDefaultSignModal
                 dAppInfo={dAppInfo}
                 chain={chain}
                 method={method}
                 data={data}
               />
-            );
-          }
-        } else {
-          return (
-            <RenderDefaultSignModal
-              dAppInfo={dAppInfo}
-              chain={chain}
-              method={method}
-              data={data}
-            />
+            </CyDView>
           );
         }
       }
@@ -592,23 +667,58 @@ const RenderSwapTransactionSignModal = ({
 const RenderApproveTokenModal = ({
   dAppInfo,
   approveTokenData,
+  decoded,
+  publicClient,
+  onRiskAssessed = noopRiskAssessed,
 }: {
   dAppInfo: IDAppInfo | undefined;
   approveTokenData: IApproveTokenData;
+  decoded?: IExtendedDecodedTxnResponse | null;
+  publicClient?: PublicClient;
+  onRiskAssessed?: (required: boolean) => void;
 }) => {
   const {
     approvalTokenLogo,
     chainLogo,
+    amount,
     spender,
     gasWithUSDAppx,
     availableBalance,
+    tokenAddress,
+    tokenSymbol,
+    ownerAddress,
   } = approveTokenData;
+
+  const { balanceRaw } = useTokenBalanceForApprove(
+    publicClient,
+    tokenAddress,
+    ownerAddress,
+  );
+
+  const risk = useMemo(
+    () => assessApproveRisk(decoded, balanceRaw),
+    [decoded, balanceRaw],
+  );
+
+  const bannerCopy = useMemo(() => approveBannerCopy(risk), [risk]);
+
+  useEffect(() => {
+    onRiskAssessed(risk.requiresHardGate);
+  }, [risk.requiresHardGate, onRiskAssessed]);
+
   return (
     <CyDView>
       {dAppInfo ? (
         <>
           <RenderDAPPInfo dAppInfo={dAppInfo} />
         </>
+      ) : null}
+      {bannerCopy ? (
+        <ScamWarningBanner
+          level={bannerCopy.level}
+          title={t<string>(bannerCopy.titleKey)}
+          message={bannerCopy.message}
+        />
       ) : null}
       <CyDView className='my-[10px]'>
         <CyDView className='flex flex-col items-center rounded-[8px] bg-n40'>
@@ -618,14 +728,14 @@ const RenderApproveTokenModal = ({
             </CyDText>
           </CyDView>
           <CyDView
-            className={'flex flex-row justify-center items-center my-[10px]'}>
-            <CyDView className='flex flex-row h-full mb-[10px] items-center self-center pr-[10px]'>
+            className={'flex flex-col justify-center items-center my-[10px]'}>
+            <CyDView className='flex flex-row h-full items-center self-center'>
               <CyDFastImage
                 className={'h-[60px] w-[60px] rounded-[50px]'}
                 source={{ uri: approvalTokenLogo }}
                 resizeMode='contain'
               />
-              <CyDView className='absolute top-[60%] right-[3px]'>
+              <CyDView className='absolute top-[60%] right-[-6px]'>
                 <CyDFastImage
                   className={
                     'h-[26px] w-[26px] rounded-[50px] border-[1px] border-n40 bg-n0'
@@ -635,8 +745,35 @@ const RenderApproveTokenModal = ({
                 />
               </CyDView>
             </CyDView>
+            {tokenSymbol ? (
+              <CyDText className='text-[14px] font-bold mt-[8px]'>
+                {tokenSymbol}
+              </CyDText>
+            ) : null}
+          </CyDView>
+          <CyDView className='pb-[14px] flex flex-col items-center'>
+            <CyDText
+              className={`text-[26px] font-extrabold ${
+                risk.isUnlimited ? 'text-errorTextRed' : ''
+              }`}>
+              {amount.inTokensWithSymbol}
+            </CyDText>
+            {amount.inUSDWithSymbol && amount.inUSDWithSymbol !== '—' ? (
+              <CyDText className='text-[14px] text-subTextColor'>
+                {amount.inUSDWithSymbol}
+              </CyDText>
+            ) : null}
           </CyDView>
         </CyDView>
+        {risk.isOverBalance && tokenSymbol ? (
+          <CyDView className='mt-[10px] rounded-[8px] bg-warningYellow border-[1px] border-warningTextYellow px-[12px] py-[10px]'>
+            <CyDText className='text-warningTextYellow text-[13px] font-medium'>
+              {t<string>('APPROVE_AMOUNT_EXCEEDS_BALANCE', {
+                symbol: tokenSymbol,
+              })}
+            </CyDText>
+          </CyDView>
+        ) : null}
         <CyDView className='my-[10px]'>
           <CyDView className={'bg-n40 rounded-[8px] py-[20px] px-[10px]'}>
             <CyDView className='flex flex-row justify-between'>

--- a/src/constants/knownDrainers.ts
+++ b/src/constants/knownDrainers.ts
@@ -1,0 +1,57 @@
+/**
+ * Curated blocklist of EVM spender addresses and domains tied to active
+ * drainer campaigns. Add entries here when support confirms a scam; bump
+ * the trailing comment with the campaign + date so we can prune later.
+ *
+ * Domain entries match the exact host plus any subdomain.
+ */
+
+const RAW_DRAINER_ADDRESSES: string[] = [
+  // farmeth.io drainer contract (`agentAddress` field served by /api/api/cs/user/getInfoA).
+  // Receives ERC20.approve and EIP-2612 Permit spending caps from victims after they sign
+  // a fake "Login" message on stakevaulteth.io and get redirected. Reported 2026-05-26.
+  '0xFaC379E4acaAe6D1fae5CD84DFB5387c18910349',
+];
+
+const RAW_SCAM_DOMAINS: string[] = [
+  'stakevaulteth.io', // honeypot Defi Farm, reported 2026-05-23
+  'farmeth.io', // drainer landing for stakevaulteth.io, reported 2026-05-25
+  'etherto.top', // related cluster, same CF backend
+  'miningent.com', // related cluster, same CF backend
+  'stayser.com', // related cluster, same CF backend
+  'defitn.ink', // related cluster, same CF backend
+  'etherh.cc', // related cluster, same CF backend
+];
+
+export const KNOWN_DRAINER_ADDRESSES: ReadonlySet<string> = new Set(
+  RAW_DRAINER_ADDRESSES.map(a => a.toLowerCase()),
+);
+
+export const KNOWN_SCAM_DOMAINS: ReadonlySet<string> = new Set(
+  RAW_SCAM_DOMAINS.map(d => d.toLowerCase()),
+);
+
+export function isKnownDrainerAddress(addr: string | undefined | null): boolean {
+  if (!addr) return false;
+  return KNOWN_DRAINER_ADDRESSES.has(addr.toLowerCase());
+}
+
+export function isKnownScamHost(host: string | undefined | null): boolean {
+  if (!host) return false;
+  const lower = host.toLowerCase().replace(/^www\./, '');
+  if (KNOWN_SCAM_DOMAINS.has(lower)) return true;
+  for (const domain of KNOWN_SCAM_DOMAINS) {
+    if (lower.endsWith('.' + domain)) return true;
+  }
+  return false;
+}
+
+export function isKnownScamUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return isKnownScamHost(parsed.hostname);
+  } catch {
+    return false;
+  }
+}

--- a/src/containers/Browser/Browser.tsx
+++ b/src/containers/Browser/Browser.tsx
@@ -32,6 +32,7 @@ import Loading from '../../components/v2/loading';
 import { INJECTED_WEB3_CDN } from '../../constants/data';
 import { Web3Origin } from '../../constants/enum';
 import { isKnownScamUrl } from '../../constants/knownDrainers';
+import { isHostScamRemote } from '../../core/securityCheck';
 import {
   Chain,
   ALL_CHAINS,
@@ -1196,6 +1197,30 @@ export default function Browser() {
                 setSearch(homePageUrl);
                 setCurrentUrl(homePageUrl);
                 return;
+              }
+              // Async server-side host check. Bundled list above is the instant
+              // floor; this catches the long tail from ScamSniffer + manual list
+              // without blocking the sync nav flow. Result is cached so SPA
+              // redirects do not hammer the endpoint.
+              try {
+                const host = new URL(navState.url).hostname;
+                void isHostScamRemote(host).then(isScam => {
+                  if (!isScam) return;
+                  webviewRef.current?.stopLoading?.();
+                  showModal('state', {
+                    type: 'error',
+                    title: t('SCAM_DOMAIN_BLOCKED_TITLE'),
+                    description: t('SCAM_DOMAIN_BLOCKED_DESCRIPTION', {
+                      url: navState.url,
+                    }),
+                    onSuccess: hideModal,
+                    onFailure: hideModal,
+                  });
+                  setSearch(homePageUrl);
+                  setCurrentUrl(homePageUrl);
+                });
+              } catch {
+                // malformed URL — let the bundled check be the floor
               }
               setCanGoBack(navState.canGoBack);
               setCurrentUrl(navState.url);

--- a/src/containers/Browser/Browser.tsx
+++ b/src/containers/Browser/Browser.tsx
@@ -31,6 +31,7 @@ import InsufficientGasFeeDescription from '../../components/v2/InsufficientGasFe
 import Loading from '../../components/v2/loading';
 import { INJECTED_WEB3_CDN } from '../../constants/data';
 import { Web3Origin } from '../../constants/enum';
+import { isKnownScamUrl } from '../../constants/knownDrainers';
 import {
   Chain,
   ALL_CHAINS,
@@ -1163,6 +1164,23 @@ export default function Browser() {
               return <Loading />;
             }}
             style={{ marginTop: 0 }}
+            onShouldStartLoadWithRequest={request => {
+              if (isKnownScamUrl(request.url)) {
+                showModal('state', {
+                  type: 'error',
+                  title: t('SCAM_DOMAIN_BLOCKED_TITLE'),
+                  description: t('SCAM_DOMAIN_BLOCKED_DESCRIPTION', {
+                    url: request.url,
+                  }),
+                  onSuccess: hideModal,
+                  onFailure: hideModal,
+                });
+                setSearch(homePageUrl);
+                setCurrentUrl(homePageUrl);
+                return false;
+              }
+              return true;
+            }}
             onNavigationStateChange={navState => {
               setCanGoBack(navState.canGoBack);
               setCurrentUrl(navState.url);

--- a/src/containers/Browser/Browser.tsx
+++ b/src/containers/Browser/Browser.tsx
@@ -1182,6 +1182,21 @@ export default function Browser() {
               return true;
             }}
             onNavigationStateChange={navState => {
+              if (isKnownScamUrl(navState.url)) {
+                webviewRef.current?.stopLoading?.();
+                showModal('state', {
+                  type: 'error',
+                  title: t('SCAM_DOMAIN_BLOCKED_TITLE'),
+                  description: t('SCAM_DOMAIN_BLOCKED_DESCRIPTION', {
+                    url: navState.url,
+                  }),
+                  onSuccess: hideModal,
+                  onFailure: hideModal,
+                });
+                setSearch(homePageUrl);
+                setCurrentUrl(homePageUrl);
+                return;
+              }
               setCanGoBack(navState.canGoBack);
               setCurrentUrl(navState.url);
             }}

--- a/src/containers/SendTo/index.tsx
+++ b/src/containers/SendTo/index.tsx
@@ -36,6 +36,7 @@ import {
 import { Colors } from '../../constants/theme';
 import { GlobalContext } from '../../core/globalContext';
 import { MODAL_HIDE_TIMEOUT_250 } from '../../core/Http';
+import { isAddressScamRemote } from '../../core/securityCheck';
 import { Holding } from '../../core/portfolio';
 import {
   ActivityContext,
@@ -124,6 +125,9 @@ export default function SendTo(props: { navigation?: any; route?: any }) {
   const [addressText, setAddressText] = useState<string>(sendAddress);
   const addressRef = useRef('');
   const ensRef = useRef<string | null>(null);
+  // User-acknowledged scam-recipient flag; tapping "Send anyway" sets it so the
+  // re-entry into submitSendTransaction doesn't show the same warning again.
+  const scamRecipientAcknowledgedRef = useRef(false);
   const [isAddressValid, setIsAddressValid] = useState(true);
   const [addressError, setAddressError] = useState<string>('');
   const [memo, setMemo] = useState<string>(t('SEND_TOKENS_MEMO'));
@@ -637,6 +641,31 @@ export default function SendTo(props: { navigation?: any; route?: any }) {
 
   const submitSendTransaction = async () => {
     setLoading(true);
+
+    // Server-side recipient blocklist check. Best-effort: failure / 5xx falls
+    // through. Bundled `knownDrainers` not consulted here because that list is
+    // spender-focused; recipient checks rely on the broader ScamSniffer corpus
+    // served by arch's SecurityService.
+    const recipientCandidate = addressText?.trim() ?? '';
+    if (recipientCandidate && !scamRecipientAcknowledgedRef.current) {
+      const isScamRecipient = await isAddressScamRemote(recipientCandidate);
+      if (isScamRecipient) {
+        setLoading(false);
+        showModal('state', {
+          type: 'warning',
+          title: t('SCAM_RECIPIENT_TITLE'),
+          description: t('SCAM_RECIPIENT_DESCRIPTION'),
+          onSuccess: () => {
+            scamRecipientAcknowledgedRef.current = true;
+            hideModal();
+            void submitSendTransaction();
+          },
+          onFailure: hideModal,
+        });
+        return;
+      }
+    }
+
     const id = genId();
     const activityData: SendTransactionActivity = {
       id,

--- a/src/containers/SendTo/index.tsx
+++ b/src/containers/SendTo/index.tsx
@@ -125,9 +125,10 @@ export default function SendTo(props: { navigation?: any; route?: any }) {
   const [addressText, setAddressText] = useState<string>(sendAddress);
   const addressRef = useRef('');
   const ensRef = useRef<string | null>(null);
-  // User-acknowledged scam-recipient flag; tapping "Send anyway" sets it so the
-  // re-entry into submitSendTransaction doesn't show the same warning again.
-  const scamRecipientAcknowledgedRef = useRef(false);
+  // User-acknowledged scam recipient (lowercased). Tapping "Send anyway" stores
+  // the resolved address here so re-entry skips the warning, but changing the
+  // recipient mid-flow re-prompts because the new address won't match.
+  const scamRecipientAcknowledgedRef = useRef<string | null>(null);
   const [isAddressValid, setIsAddressValid] = useState(true);
   const [addressError, setAddressError] = useState<string>('');
   const [memo, setMemo] = useState<string>(t('SEND_TOKENS_MEMO'));
@@ -642,30 +643,6 @@ export default function SendTo(props: { navigation?: any; route?: any }) {
   const submitSendTransaction = async () => {
     setLoading(true);
 
-    // Server-side recipient blocklist check. Best-effort: failure / 5xx falls
-    // through. Bundled `knownDrainers` not consulted here because that list is
-    // spender-focused; recipient checks rely on the broader ScamSniffer corpus
-    // served by arch's SecurityService.
-    const recipientCandidate = addressText?.trim() ?? '';
-    if (recipientCandidate && !scamRecipientAcknowledgedRef.current) {
-      const isScamRecipient = await isAddressScamRemote(recipientCandidate);
-      if (isScamRecipient) {
-        setLoading(false);
-        showModal('state', {
-          type: 'warning',
-          title: t('SCAM_RECIPIENT_TITLE'),
-          description: t('SCAM_RECIPIENT_DESCRIPTION'),
-          onSuccess: () => {
-            scamRecipientAcknowledgedRef.current = true;
-            hideModal();
-            void submitSendTransaction();
-          },
-          onFailure: hideModal,
-        });
-        return;
-      }
-    }
-
     const id = genId();
     const activityData: SendTransactionActivity = {
       id,
@@ -708,6 +685,33 @@ export default function SendTo(props: { navigation?: any; route?: any }) {
           title: t('NOT_VALID_ENS'),
           description: `This ens domain is not mapped for ${tokenData.chainDetails.name.toLowerCase()} in ens.domains`,
           onSuccess: hideModal,
+          onFailure: hideModal,
+        });
+        return;
+      }
+    }
+
+    // Server-side recipient blocklist check on the RESOLVED address so an ENS
+    // that resolves to a known drainer is still caught. Best-effort: any 5xx /
+    // network failure falls through. Acknowledged-recipient ref is keyed on the
+    // resolved address so switching recipients re-prompts.
+    const resolvedRecipient = addressRef.current?.trim().toLowerCase() ?? '';
+    if (
+      resolvedRecipient &&
+      scamRecipientAcknowledgedRef.current !== resolvedRecipient
+    ) {
+      const isScamRecipient = await isAddressScamRemote(resolvedRecipient);
+      if (isScamRecipient) {
+        setLoading(false);
+        showModal('state', {
+          type: 'warning',
+          title: t('SCAM_RECIPIENT_TITLE'),
+          description: t('SCAM_RECIPIENT_DESCRIPTION'),
+          onSuccess: () => {
+            scamRecipientAcknowledgedRef.current = resolvedRecipient;
+            hideModal();
+            void submitSendTransaction();
+          },
           onFailure: hideModal,
         });
         return;

--- a/src/core/securityCheck.ts
+++ b/src/core/securityCheck.ts
@@ -87,6 +87,20 @@ export async function checkSecurity(input: {
       result.hosts[host] = Boolean(hit);
       writeCache(hostCache, host, Boolean(hit));
     }
+    // Backfill any inputs the server omitted from the response so the cache
+    // remembers the "miss" verdict instead of re-asking next call.
+    for (const addr of uncachedAddresses) {
+      if (!(addr in result.addresses)) {
+        result.addresses[addr] = false;
+        writeCache(addressCache, addr, false);
+      }
+    }
+    for (const host of uncachedHosts) {
+      if (!(host in result.hosts)) {
+        result.hosts[host] = false;
+        writeCache(hostCache, host, false);
+      }
+    }
   } catch {
     // Fail open — leave uncached entries as `false`. Bundled list covers the floor.
     for (const addr of uncachedAddresses) result.addresses[addr] = false;

--- a/src/core/securityCheck.ts
+++ b/src/core/securityCheck.ts
@@ -1,0 +1,113 @@
+import axios from 'axios';
+import { hostWorker } from '../global';
+
+interface SecurityCheckResponse {
+  addresses: Record<string, boolean>;
+  hosts: Record<string, boolean>;
+}
+
+interface CacheEntry {
+  value: boolean;
+  expiresAt: number;
+}
+
+const ENDPOINT_PATH = '/v1/security/check';
+const REQUEST_TIMEOUT_MS = 4_000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const addressCache = new Map<string, CacheEntry>();
+const hostCache = new Map<string, CacheEntry>();
+
+const now = (): number => Date.now();
+
+const readCache = (cache: Map<string, CacheEntry>, key: string): boolean | undefined => {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (entry.expiresAt < now()) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+};
+
+const writeCache = (cache: Map<string, CacheEntry>, key: string, value: boolean): void => {
+  cache.set(key, { value, expiresAt: now() + CACHE_TTL_MS });
+};
+
+const normaliseAddress = (addr: string): string => addr.trim().toLowerCase();
+const normaliseHost = (host: string): string => host.trim().toLowerCase().replace(/^www\./, '');
+
+/**
+ * Calls arch's POST /v1/security/check endpoint. Best-effort: any failure (network,
+ * timeout, 5xx) resolves to "not scam" for every input so the wallet never blocks a
+ * legitimate flow because the security service is unreachable. Bundled `knownDrainers`
+ * remains the offline floor.
+ */
+export async function checkSecurity(input: {
+  addresses?: string[];
+  hosts?: string[];
+}): Promise<SecurityCheckResponse> {
+  const addresses = (input.addresses ?? []).map(normaliseAddress).filter(Boolean);
+  const hosts = (input.hosts ?? []).map(normaliseHost).filter(Boolean);
+
+  const result: SecurityCheckResponse = { addresses: {}, hosts: {} };
+
+  const uncachedAddresses: string[] = [];
+  for (const addr of addresses) {
+    const cached = readCache(addressCache, addr);
+    if (cached === undefined) uncachedAddresses.push(addr);
+    else result.addresses[addr] = cached;
+  }
+  const uncachedHosts: string[] = [];
+  for (const host of hosts) {
+    const cached = readCache(hostCache, host);
+    if (cached === undefined) uncachedHosts.push(host);
+    else result.hosts[host] = cached;
+  }
+
+  if (uncachedAddresses.length === 0 && uncachedHosts.length === 0) {
+    return result;
+  }
+
+  try {
+    const base = hostWorker.getHost('ARCH_HOST');
+    const { data } = await axios.post<SecurityCheckResponse>(
+      `${base}${ENDPOINT_PATH}`,
+      {
+        addresses: uncachedAddresses.length ? uncachedAddresses : undefined,
+        hosts: uncachedHosts.length ? uncachedHosts : undefined,
+      },
+      { timeout: REQUEST_TIMEOUT_MS },
+    );
+    for (const [addr, hit] of Object.entries(data?.addresses ?? {})) {
+      result.addresses[addr] = Boolean(hit);
+      writeCache(addressCache, addr, Boolean(hit));
+    }
+    for (const [host, hit] of Object.entries(data?.hosts ?? {})) {
+      result.hosts[host] = Boolean(hit);
+      writeCache(hostCache, host, Boolean(hit));
+    }
+  } catch {
+    // Fail open — leave uncached entries as `false`. Bundled list covers the floor.
+    for (const addr of uncachedAddresses) result.addresses[addr] = false;
+    for (const host of uncachedHosts) result.hosts[host] = false;
+  }
+
+  return result;
+}
+
+export async function isAddressScamRemote(addr: string | null | undefined): Promise<boolean> {
+  if (!addr) return false;
+  const lower = normaliseAddress(addr);
+  if (!lower) return false;
+  const result = await checkSecurity({ addresses: [lower] });
+  return Boolean(result.addresses[lower]);
+}
+
+export async function isHostScamRemote(host: string | null | undefined): Promise<boolean> {
+  if (!host) return false;
+  const lower = normaliseHost(host);
+  if (!lower) return false;
+  const result = await checkSecurity({ hosts: [lower] });
+  return Boolean(result.hosts[lower]);
+}

--- a/src/hooks/useTokenBalanceForApprove.ts
+++ b/src/hooks/useTokenBalanceForApprove.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import type { PublicClient } from 'viem';
+
+const ERC20_BALANCE_ABI = [
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;
+
+function isLikelyAddress(value: string | undefined): value is `0x${string}` {
+  return Boolean(value && /^0x[0-9a-fA-F]{40}$/.test(value));
+}
+
+export function useTokenBalanceForApprove(
+  publicClient: PublicClient | undefined,
+  tokenAddress: string | undefined,
+  ownerAddress: string | undefined,
+): { balanceRaw: bigint | null; isLoading: boolean } {
+  const [balanceRaw, setBalanceRaw] = useState<bigint | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!publicClient || !isLikelyAddress(tokenAddress) || !isLikelyAddress(ownerAddress)) {
+      setBalanceRaw(null);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    publicClient
+      .readContract({
+        address: tokenAddress,
+        abi: ERC20_BALANCE_ABI,
+        functionName: 'balanceOf',
+        args: [ownerAddress],
+      })
+      .then(result => {
+        if (cancelled) return;
+        setBalanceRaw(result);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setBalanceRaw(null);
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [publicClient, tokenAddress, ownerAddress]);
+
+  return { balanceRaw, isLoading };
+}

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import type { PublicClient } from 'viem';
+
+const ERC20_BALANCE_ABI = [
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;
+
+function isLikelyAddress(value: string | undefined): value is `0x${string}` {
+  return Boolean(value && /^0x[0-9a-fA-F]{40}$/.test(value));
+}
+
+export function useTokenBalances(
+  publicClient: PublicClient | undefined,
+  tokenAddresses: readonly string[],
+  ownerAddress: string | undefined,
+): { balances: Map<string, bigint | null>; isLoading: boolean } {
+  const [balances, setBalances] = useState<Map<string, bigint | null>>(
+    new Map(),
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const key = `${ownerAddress ?? ''}|${tokenAddresses.map(t => t.toLowerCase()).join(',')}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!publicClient || !isLikelyAddress(ownerAddress)) {
+      setBalances(new Map());
+      setIsLoading(false);
+      return;
+    }
+    const validTokens = tokenAddresses.filter(isLikelyAddress);
+    if (validTokens.length === 0) {
+      setBalances(new Map());
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    const fetchAll = async (): Promise<void> => {
+      const results = await Promise.all(
+        validTokens.map(async addr => {
+          try {
+            const value = await publicClient.readContract({
+              address: addr,
+              abi: ERC20_BALANCE_ABI,
+              functionName: 'balanceOf',
+              args: [ownerAddress],
+            });
+            return [addr.toLowerCase(), value] as const;
+          } catch {
+            return [addr.toLowerCase(), null] as const;
+          }
+        }),
+      );
+      if (cancelled) return;
+      const next = new Map<string, bigint | null>();
+      for (const [addr, value] of results) {
+        next.set(addr, value);
+      }
+      setBalances(next);
+      setIsLoading(false);
+    };
+    void fetchAll();
+    return () => {
+      cancelled = true;
+    };
+  }, [publicClient, key, ownerAddress, tokenAddresses]);
+
+  return { balances, isLoading };
+}

--- a/src/hooks/useWalletConnectV2EventsManager/index.ts
+++ b/src/hooks/useWalletConnectV2EventsManager/index.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { SignClientTypes } from '@walletconnect/types';
+import { getSdkError } from '@walletconnect/utils';
 import { useCallback, useContext, useEffect, useRef } from 'react';
-import { deleteTopic, web3wallet } from '../../core/walletConnectV2Utils';
+import { web3wallet } from '../../core/walletConnectV2Utils';
+import { isHostScamRemote } from '../../core/securityCheck';
+import { isKnownScamHost } from '../../constants/knownDrainers';
 import {
   COSMOS_SIGNING_METHODS,
   EIP155_SIGNING_METHODS,
@@ -30,12 +32,45 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
   const { showModal, hideModal } = globalModalContext || {};
 
   const onSessionProposal = useCallback(
-    (proposal: any) => {
+    async (proposal: any) => {
       if (!showModal || !ethereum?.wallets?.[ethereum?.currentIndex]?.address) {
         console.error(
           '[WalletConnect] Missing dependencies for session proposal',
         );
         return;
+      }
+
+      // Block scam dApp origins before the pairing modal renders. Bundled
+      // `isKnownScamHost` is the offline floor; arch's SecurityService extends
+      // coverage to the ScamSniffer corpus.
+      try {
+        const dappUrl: string | undefined =
+          proposal?.params?.proposer?.metadata?.url;
+        if (dappUrl) {
+          const host = new URL(dappUrl).hostname;
+          const isScam =
+            isKnownScamHost(host) || (await isHostScamRemote(host));
+          if (isScam) {
+            try {
+              await web3wallet?.rejectSession({
+                id: proposal.id,
+                reason: getSdkError('USER_REJECTED'),
+              });
+            } catch (rejectErr) {
+              Sentry.captureException(rejectErr);
+            }
+            showModal('state', {
+              type: 'error',
+              title: t('SCAM_DOMAIN_BLOCKED_TITLE'),
+              description: t('SCAM_DOMAIN_BLOCKED_DESCRIPTION', { url: dappUrl }),
+              onSuccess: hideModal,
+              onFailure: hideModal,
+            });
+            return;
+          }
+        }
+      } catch {
+        // Malformed URL or network blip — fall through to pairing modal.
       }
 
       showModal(GlobalModalType.WALLET_CONNECT_V2_PAIRING, {
@@ -213,7 +248,7 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
 
   /******************************************************************************
    * Set up WalletConnect event listeners
-   * 
+   *
    * IMPORTANT: We use refs for callbacks to avoid the cleanup/re-register cycle
    * that was causing "No listener for session_proposal event" errors.
    * The listeners are registered once and use refs to always call the latest callback.
@@ -241,7 +276,7 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
     if (initialized && web3wallet && !listenersRegistered.current) {
       // Store handler references for cleanup
       handlersRef.current.proposal = (proposal: any) => {
-        onSessionProposalRef.current?.(proposal);
+        void onSessionProposalRef.current?.(proposal);
       };
       handlersRef.current.request = (request: any) => {
         void onSessionRequestRef.current?.(request);

--- a/src/hooks/useWalletConnectV2EventsManager/index.ts
+++ b/src/hooks/useWalletConnectV2EventsManager/index.ts
@@ -43,34 +43,43 @@ export default function useWalletConnectEventsManager(initialized: boolean) {
       // Block scam dApp origins before the pairing modal renders. Bundled
       // `isKnownScamHost` is the offline floor; arch's SecurityService extends
       // coverage to the ScamSniffer corpus.
-      try {
-        const dappUrl: string | undefined =
-          proposal?.params?.proposer?.metadata?.url;
-        if (dappUrl) {
-          const host = new URL(dappUrl).hostname;
-          const isScam =
-            isKnownScamHost(host) || (await isHostScamRemote(host));
-          if (isScam) {
-            try {
-              await web3wallet?.rejectSession({
-                id: proposal.id,
-                reason: getSdkError('USER_REJECTED'),
-              });
-            } catch (rejectErr) {
-              Sentry.captureException(rejectErr);
-            }
-            showModal('state', {
-              type: 'error',
-              title: t('SCAM_DOMAIN_BLOCKED_TITLE'),
-              description: t('SCAM_DOMAIN_BLOCKED_DESCRIPTION', { url: dappUrl }),
-              onSuccess: hideModal,
-              onFailure: hideModal,
-            });
-            return;
-          }
+      const dappUrl: string | undefined =
+        proposal?.params?.proposer?.metadata?.url;
+      if (dappUrl) {
+        // Normalise scheme-less URLs (e.g. `farmeth.io`) so `new URL` doesn't
+        // throw and let a malformed value bypass the check.
+        const normalisedUrl = /^https?:\/\//i.test(dappUrl)
+          ? dappUrl
+          : `https://${dappUrl}`;
+        let host: string | null = null;
+        try {
+          host = new URL(normalisedUrl).hostname;
+        } catch {
+          host = null;
         }
-      } catch {
-        // Malformed URL or network blip — fall through to pairing modal.
+        // Treat unparseable proposer metadata as untrusted: reject + warn.
+        const isScam =
+          host === null ||
+          isKnownScamHost(host) ||
+          (await isHostScamRemote(host));
+        if (isScam) {
+          try {
+            await web3wallet?.rejectSession({
+              id: proposal.id,
+              reason: getSdkError('USER_REJECTED'),
+            });
+          } catch (rejectErr) {
+            Sentry.captureException(rejectErr);
+          }
+          showModal('state', {
+            type: 'error',
+            title: t('SCAM_DOMAIN_BLOCKED_TITLE'),
+            description: t('SCAM_DOMAIN_BLOCKED_DESCRIPTION', { url: dappUrl }),
+            onSuccess: hideModal,
+            onFailure: hideModal,
+          });
+          return;
+        }
       }
 
       showModal(GlobalModalType.WALLET_CONNECT_V2_PAIRING, {

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -913,6 +913,12 @@ const resources = {
       APPROVE_AMOUNT_EXCEEDS_BALANCE:
         'The approval amount is greater than your current {{symbol}} balance. Verify the amount before proceeding.',
       PERMIT_AMOUNT_EXCEEDS_BALANCE: 'Exceeds current balance',
+      PERMIT_AMOUNT_UNLIMITED: 'Unlimited {{symbol}}',
+      PERMIT_AMOUNT_RAW: '{{amount}} {{symbol}} (raw units)',
+      PERMIT_EXPIRES_AT: 'Expires {{when}}',
+      PERMIT_KIND_EIP2612: 'Off-chain approval (EIP-2612)',
+      PERMIT_KIND_PERMIT2_SINGLE: 'Off-chain approval (Permit2)',
+      PERMIT_KIND_PERMIT2_BATCH: 'Off-chain batch approval (Permit2)',
       DEADLINE: 'Deadline',
       SCAM_DOMAIN_BLOCKED_TITLE: 'Scam site blocked',
       SCAM_DOMAIN_BLOCKED_DESCRIPTION:

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -912,6 +912,8 @@ const resources = {
       RISK_FOOTER_IGNORE_ALL: 'Ignore all',
       APPROVE_AMOUNT_EXCEEDS_BALANCE:
         'The approval amount is greater than your current {{symbol}} balance. Verify the amount before proceeding.',
+      PERMIT_AMOUNT_EXCEEDS_BALANCE: 'Exceeds current balance',
+      DEADLINE: 'Deadline',
       METHOD: 'Method',
       WALLET_CONNECT_PROPOSAL_EXPIRED: 'Connection request expired',
       WC_PROPOSAL_EXPIRED_DESCRIPTION:

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -914,6 +914,9 @@ const resources = {
         'The approval amount is greater than your current {{symbol}} balance. Verify the amount before proceeding.',
       PERMIT_AMOUNT_EXCEEDS_BALANCE: 'Exceeds current balance',
       DEADLINE: 'Deadline',
+      SCAM_DOMAIN_BLOCKED_TITLE: 'Scam site blocked',
+      SCAM_DOMAIN_BLOCKED_DESCRIPTION:
+        '{{url}} is on our known-scam list. Reported by support and confirmed to drain wallets. Returning to home page.',
       METHOD: 'Method',
       WALLET_CONNECT_PROPOSAL_EXPIRED: 'Connection request expired',
       WC_PROPOSAL_EXPIRED_DESCRIPTION:

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -905,6 +905,13 @@ const resources = {
       APPROVAL_TOKEN: 'Approval Token',
       SPENDER: 'Spender',
       APPROVE_TO: 'Approve to',
+      SCAM_WARNING_TITLE: 'Scam detected',
+      SUSPICIOUS_WARNING_TITLE: 'Proceed with caution',
+      ACKNOWLEDGE_RISK_TITLE: 'Acknowledge risk',
+      RISK_FOOTER_MESSAGE: 'Please review the alert above before signing.',
+      RISK_FOOTER_IGNORE_ALL: 'Ignore all',
+      APPROVE_AMOUNT_EXCEEDS_BALANCE:
+        'The approval amount is greater than your current {{symbol}} balance. Verify the amount before proceeding.',
       METHOD: 'Method',
       WALLET_CONNECT_PROPOSAL_EXPIRED: 'Connection request expired',
       WC_PROPOSAL_EXPIRED_DESCRIPTION:

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -912,6 +912,9 @@ const resources = {
       RISK_FOOTER_IGNORE_ALL: 'Ignore all',
       APPROVE_AMOUNT_EXCEEDS_BALANCE:
         'The approval amount is greater than your current {{symbol}} balance. Verify the amount before proceeding.',
+      SCAM_RECIPIENT_TITLE: 'Recipient flagged as scam',
+      SCAM_RECIPIENT_DESCRIPTION:
+        'This address is on our known-drainer list. Sending here usually means your funds are lost. Cancel and double-check the address, or tap continue to send anyway.',
       PERMIT_AMOUNT_EXCEEDS_BALANCE: 'Exceeds current balance',
       PERMIT_AMOUNT_UNLIMITED: 'Unlimited {{symbol}}',
       PERMIT_AMOUNT_RAW: '{{amount}} {{symbol}} (raw units)',

--- a/src/models/signingModalData.interface.ts
+++ b/src/models/signingModalData.interface.ts
@@ -116,6 +116,9 @@ export interface IApproveTokenData {
   };
   gasWithUSDAppx: string;
   availableBalance: string;
+  tokenAddress: string;
+  tokenSymbol: string;
+  ownerAddress: string;
 }
 
 export interface IDAppInfo {

--- a/src/models/txnDecode.interface.ts
+++ b/src/models/txnDecode.interface.ts
@@ -257,6 +257,12 @@ export interface IDecodedTransactionResponse {
     token_symbol: string
     token_amount: number
     token: DeBankToken
+    /**
+     * Server-side scam flag for the recipient `to_addr`, populated by arch's
+     * SecurityService against ScamSniffer + manual blocklist.
+     * Optional so older backends that don't send it behave identically (undefined ≈ false).
+     */
+    is_scam_recipient?: boolean
   }
   // Contract call - swap
   type_call?: {
@@ -276,6 +282,7 @@ export interface IDecodedTransactionResponse {
     is_nft: boolean
     nft: null | DeBankNft
     token: DeBankToken
+    is_scam_spender?: boolean
   }
   // Revoke
   type_cancel_token_approval?: {

--- a/src/utils/approveGuard.ts
+++ b/src/utils/approveGuard.ts
@@ -385,10 +385,13 @@ export function assessSendRisk(
   for (const token of decoded.balance_change?.receive_token_list ?? []) {
     visit(token);
   }
-  // Recipient blocklist hit comes from arch's SecurityService check on
-  // `type_send.to_addr`. Bundled drainer list is not consulted here because
-  // it is spender-focused; the server already unions ScamSniffer + manual.
-  const isScamRecipient = Boolean(decoded.type_send?.is_scam_recipient);
+  // Recipient blocklist hit: server-side flag unioned with the bundled drainer
+  // list. Bundled inclusion handles older arch versions that don't yet return
+  // `is_scam_recipient`, and keeps the offline floor working when the network
+  // check times out at the server layer.
+  const isScamRecipient =
+    Boolean(decoded.type_send?.is_scam_recipient) ||
+    isKnownDrainerAddress(decoded.type_send?.to_addr);
   const reasons: string[] = [];
   if (isScamRecipient) {
     reasons.push(

--- a/src/utils/approveGuard.ts
+++ b/src/utils/approveGuard.ts
@@ -2,6 +2,7 @@ import type {
   DeBankToken,
   IDecodedTransactionResponse,
 } from '../models/txnDecode.interface';
+import type { NormalizedPermit, PermitItem } from './permitParser';
 
 const UINT256_MAX = BigInt(
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
@@ -54,6 +55,108 @@ export type ApproveBannerCopy = {
   titleKey: string;
   message: string;
 } | null;
+
+export interface PermitRiskAssessment {
+  level: ApproveRiskLevel;
+  isUnlimited: boolean;
+  isFarOverBalance: boolean;
+  isOverBalance: boolean;
+  requiresHardGate: boolean;
+  perItem: PermitItemAssessment[];
+}
+
+export interface PermitItemAssessment {
+  item: PermitItem;
+  isUnlimited: boolean;
+  isOverBalance: boolean;
+  isFarOverBalance: boolean;
+  balanceRaw: bigint | null;
+}
+
+export function assessPermitRisk(
+  permit: NormalizedPermit | null | undefined,
+  balanceLookup: (tokenAddress: string) => bigint | null,
+): PermitRiskAssessment {
+  const empty: PermitRiskAssessment = {
+    level: 'none',
+    isUnlimited: false,
+    isFarOverBalance: false,
+    isOverBalance: false,
+    requiresHardGate: false,
+    perItem: [],
+  };
+  if (!permit) return empty;
+
+  let isUnlimited = false;
+  let isOverBalance = false;
+  let isFarOverBalance = false;
+  const perItem: PermitItemAssessment[] = [];
+
+  for (const item of permit.items) {
+    const balanceRaw = balanceLookup(item.token);
+    const overBalance =
+      !item.isUnlimited && balanceRaw !== null && item.amount > balanceRaw;
+    const farOverBalance =
+      !item.isUnlimited &&
+      balanceRaw !== null &&
+      balanceRaw > 0n &&
+      item.amount > balanceRaw * BigInt(OVER_BALANCE_MULTIPLE_BLOCK);
+    if (item.isUnlimited) isUnlimited = true;
+    if (overBalance) isOverBalance = true;
+    if (farOverBalance) isFarOverBalance = true;
+    perItem.push({
+      item,
+      isUnlimited: item.isUnlimited,
+      isOverBalance: overBalance,
+      isFarOverBalance: farOverBalance,
+      balanceRaw,
+    });
+  }
+
+  const requiresHardGate = isUnlimited || isFarOverBalance;
+  const level: ApproveRiskLevel =
+    isUnlimited || isFarOverBalance
+      ? 'danger'
+      : isOverBalance
+        ? 'warn'
+        : 'none';
+  return {
+    level,
+    isUnlimited,
+    isFarOverBalance,
+    isOverBalance,
+    requiresHardGate,
+    perItem,
+  };
+}
+
+export function permitBannerCopy(risk: PermitRiskAssessment): ApproveBannerCopy {
+  if (risk.isUnlimited) {
+    return {
+      level: 'danger',
+      titleKey: 'ACKNOWLEDGE_RISK_TITLE',
+      message:
+        'Site requests an off-chain unlimited approval (permit). Scammers use this to drain wallets without spending gas.',
+    };
+  }
+  if (risk.isFarOverBalance) {
+    return {
+      level: 'danger',
+      titleKey: 'ACKNOWLEDGE_RISK_TITLE',
+      message:
+        'Permit amount is far above your current balance. Common drainer pattern.',
+    };
+  }
+  if (risk.isOverBalance) {
+    return {
+      level: 'warn',
+      titleKey: 'SUSPICIOUS_WARNING_TITLE',
+      message:
+        'Permit amount exceeds your current balance. Verify before signing.',
+    };
+  }
+  return null;
+}
 
 export function approveBannerCopy(risk: ApproveRiskAssessment): ApproveBannerCopy {
   if (risk.isScamToken) {

--- a/src/utils/approveGuard.ts
+++ b/src/utils/approveGuard.ts
@@ -3,6 +3,7 @@ import type {
   IDecodedTransactionResponse,
 } from '../models/txnDecode.interface';
 import type { NormalizedPermit, PermitItem } from './permitParser';
+import { isKnownDrainerAddress } from '../constants/knownDrainers';
 
 const UINT256_MAX = BigInt(
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
@@ -18,6 +19,7 @@ export interface ApproveRiskAssessment {
   level: ApproveRiskLevel;
   isScamToken: boolean;
   isSuspiciousToken: boolean;
+  isScamSpender: boolean;
   isUnlimited: boolean;
   isOverBalance: boolean;
   isFarOverBalance: boolean;
@@ -61,6 +63,7 @@ export interface PermitRiskAssessment {
   isUnlimited: boolean;
   isFarOverBalance: boolean;
   isOverBalance: boolean;
+  isScamSpender: boolean;
   requiresHardGate: boolean;
   perItem: PermitItemAssessment[];
 }
@@ -82,6 +85,7 @@ export function assessPermitRisk(
     isUnlimited: false,
     isFarOverBalance: false,
     isOverBalance: false,
+    isScamSpender: false,
     requiresHardGate: false,
     perItem: [],
   };
@@ -90,6 +94,7 @@ export function assessPermitRisk(
   let isUnlimited = false;
   let isOverBalance = false;
   let isFarOverBalance = false;
+  const isScamSpender = isKnownDrainerAddress(permit.spender);
   const perItem: PermitItemAssessment[] = [];
 
   for (const item of permit.items) {
@@ -113,9 +118,9 @@ export function assessPermitRisk(
     });
   }
 
-  const requiresHardGate = isUnlimited || isFarOverBalance;
+  const requiresHardGate = isScamSpender || isUnlimited || isFarOverBalance;
   const level: ApproveRiskLevel =
-    isUnlimited || isFarOverBalance
+    isScamSpender || isUnlimited || isFarOverBalance
       ? 'danger'
       : isOverBalance
         ? 'warn'
@@ -125,12 +130,21 @@ export function assessPermitRisk(
     isUnlimited,
     isFarOverBalance,
     isOverBalance,
+    isScamSpender,
     requiresHardGate,
     perItem,
   };
 }
 
 export function permitBannerCopy(risk: PermitRiskAssessment): ApproveBannerCopy {
+  if (risk.isScamSpender) {
+    return {
+      level: 'danger',
+      titleKey: 'SCAM_WARNING_TITLE',
+      message:
+        'Spender address is on our known-drainer list. Do not sign.',
+    };
+  }
   if (risk.isUnlimited) {
     return {
       level: 'danger',
@@ -159,6 +173,14 @@ export function permitBannerCopy(risk: PermitRiskAssessment): ApproveBannerCopy 
 }
 
 export function approveBannerCopy(risk: ApproveRiskAssessment): ApproveBannerCopy {
+  if (risk.isScamSpender) {
+    return {
+      level: 'danger',
+      titleKey: 'SCAM_WARNING_TITLE',
+      message:
+        'Spender address is on our known-drainer list. Do not approve.',
+    };
+  }
   if (risk.isScamToken) {
     return {
       level: 'danger',
@@ -221,6 +243,7 @@ export function assessApproveRisk(
     level: 'none',
     isScamToken: false,
     isSuspiciousToken: false,
+    isScamSpender: false,
     isUnlimited: false,
     isOverBalance: false,
     isFarOverBalance: false,
@@ -236,6 +259,7 @@ export function assessApproveRisk(
   const token: DeBankToken | undefined = approval.token;
   const isScamToken = Boolean(token?.is_scam);
   const isSuspiciousToken = Boolean(token?.is_suspicious);
+  const isScamSpender = isKnownDrainerAddress(approval.spender);
 
   const amountRaw =
     safeParseAmount(token?.raw_amount_str) ??
@@ -266,6 +290,10 @@ export function assessApproveRisk(
   const reasons: string[] = [];
   let level: ApproveRiskLevel = 'none';
 
+  if (isScamSpender) {
+    reasons.push('Spender address flagged as known drainer.');
+    level = 'danger';
+  }
   if (isScamToken) {
     reasons.push('Token flagged as scam by our database.');
     level = 'danger';
@@ -290,12 +318,13 @@ export function assessApproveRisk(
     level = 'warn';
   }
 
-  const requiresHardGate = isUnlimited || isFarOverBalance;
+  const requiresHardGate = isScamSpender || isUnlimited || isFarOverBalance;
 
   return {
     level,
     isScamToken,
     isSuspiciousToken,
+    isScamSpender,
     isUnlimited,
     isOverBalance,
     isFarOverBalance,

--- a/src/utils/approveGuard.ts
+++ b/src/utils/approveGuard.ts
@@ -311,7 +311,6 @@ export function assessApproveRisk(
     if (level !== 'danger') level = 'danger';
   } else if (isOverBalance) {
     reasons.push("Approval amount exceeds your current token balance.");
-    if (level !== 'danger') level = 'warn';
   }
   if (isSuspiciousToken && level === 'none') {
     reasons.push('Token marked as suspicious.');

--- a/src/utils/approveGuard.ts
+++ b/src/utils/approveGuard.ts
@@ -1,0 +1,244 @@
+import type {
+  DeBankToken,
+  IDecodedTransactionResponse,
+} from '../models/txnDecode.interface';
+
+const UINT256_MAX = BigInt(
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+);
+
+const NEAR_MAX_THRESHOLD = UINT256_MAX / 2n;
+
+const OVER_BALANCE_MULTIPLE_BLOCK = 10;
+
+export type ApproveRiskLevel = 'none' | 'info' | 'warn' | 'danger';
+
+export interface ApproveRiskAssessment {
+  level: ApproveRiskLevel;
+  isScamToken: boolean;
+  isSuspiciousToken: boolean;
+  isUnlimited: boolean;
+  isOverBalance: boolean;
+  isFarOverBalance: boolean;
+  amountRaw: bigint | null;
+  amountFormatted: string | null;
+  approveUsdValue: number | null;
+  reasons: string[];
+  requiresHardGate: boolean;
+}
+
+export function isNearMaxAllowance(amount: bigint): boolean {
+  return amount >= NEAR_MAX_THRESHOLD;
+}
+
+function safeParseAmount(value: string | number | undefined): bigint | null {
+  if (value === undefined || value === null) return null;
+  try {
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) return null;
+      return BigInt(Math.trunc(value));
+    }
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (trimmed.startsWith('0x') || trimmed.startsWith('0X')) {
+      return BigInt(trimmed);
+    }
+    return BigInt(trimmed.split('.')[0]);
+  } catch {
+    return null;
+  }
+}
+
+export type ApproveBannerCopy = {
+  level: ApproveRiskLevel;
+  titleKey: string;
+  message: string;
+} | null;
+
+export function approveBannerCopy(risk: ApproveRiskAssessment): ApproveBannerCopy {
+  if (risk.isScamToken) {
+    return {
+      level: 'danger',
+      titleKey: 'SCAM_WARNING_TITLE',
+      message: 'Token flagged as scam by our database.',
+    };
+  }
+  if (risk.isUnlimited) {
+    return {
+      level: 'danger',
+      titleKey: 'ACKNOWLEDGE_RISK_TITLE',
+      message:
+        'Site requests unlimited approval. Scammers use this to drain wallets.',
+    };
+  }
+  if (risk.isFarOverBalance) {
+    return {
+      level: 'danger',
+      titleKey: 'ACKNOWLEDGE_RISK_TITLE',
+      message:
+        'Approval amount is far above your current balance. Common drainer pattern.',
+    };
+  }
+  if (risk.isSuspiciousToken) {
+    return {
+      level: 'warn',
+      titleKey: 'SUSPICIOUS_WARNING_TITLE',
+      message: 'Token marked as suspicious by our database.',
+    };
+  }
+  return null;
+}
+
+export function sendBannerCopy(sendRisk: {
+  isScam: boolean;
+  isSuspicious: boolean;
+}): ApproveBannerCopy {
+  if (sendRisk.isScam) {
+    return {
+      level: 'danger',
+      titleKey: 'SCAM_WARNING_TITLE',
+      message: 'A token in this transaction is flagged as scam.',
+    };
+  }
+  if (sendRisk.isSuspicious) {
+    return {
+      level: 'warn',
+      titleKey: 'SUSPICIOUS_WARNING_TITLE',
+      message: 'A token in this transaction is marked as suspicious.',
+    };
+  }
+  return null;
+}
+
+export function assessApproveRisk(
+  decoded: IDecodedTransactionResponse | null | undefined,
+  walletBalanceRaw?: bigint | null,
+): ApproveRiskAssessment {
+  const empty: ApproveRiskAssessment = {
+    level: 'none',
+    isScamToken: false,
+    isSuspiciousToken: false,
+    isUnlimited: false,
+    isOverBalance: false,
+    isFarOverBalance: false,
+    amountRaw: null,
+    amountFormatted: null,
+    approveUsdValue: null,
+    reasons: [],
+    requiresHardGate: false,
+  };
+  const approval = decoded?.type_token_approval;
+  if (!approval) return empty;
+
+  const token: DeBankToken | undefined = approval.token;
+  const isScamToken = Boolean(token?.is_scam);
+  const isSuspiciousToken = Boolean(token?.is_suspicious);
+
+  const amountRaw =
+    safeParseAmount(token?.raw_amount_str) ??
+    safeParseAmount(token?.raw_amount_hex_str) ??
+    safeParseAmount(approval.token_amount);
+
+  const isUnlimited =
+    Boolean(approval.is_infinity) ||
+    (amountRaw !== null && isNearMaxAllowance(amountRaw));
+
+  const balanceRaw = walletBalanceRaw ?? null;
+  const isOverBalance =
+    amountRaw !== null && balanceRaw !== null && balanceRaw >= 0n
+      ? !isUnlimited && amountRaw > balanceRaw
+      : false;
+  const isFarOverBalance =
+    amountRaw !== null && balanceRaw !== null && balanceRaw > 0n
+      ? !isUnlimited &&
+        amountRaw > balanceRaw * BigInt(OVER_BALANCE_MULTIPLE_BLOCK)
+      : false;
+
+  const approveUsdValue =
+    typeof approval.token_amount === 'number' &&
+    typeof token?.price === 'number'
+      ? approval.token_amount * token.price
+      : null;
+
+  const reasons: string[] = [];
+  let level: ApproveRiskLevel = 'none';
+
+  if (isScamToken) {
+    reasons.push('Token flagged as scam by our database.');
+    level = 'danger';
+  }
+  if (isUnlimited) {
+    reasons.push(
+      'Site requests unlimited approval. Scammers use this to drain wallets.',
+    );
+    if (level !== 'danger') level = 'danger';
+  }
+  if (isFarOverBalance) {
+    reasons.push(
+      'Approval amount is far above your current balance. Common drainer pattern.',
+    );
+    if (level !== 'danger') level = 'danger';
+  } else if (isOverBalance) {
+    reasons.push("Approval amount exceeds your current token balance.");
+    if (level !== 'danger') level = 'warn';
+  }
+  if (isSuspiciousToken && level === 'none') {
+    reasons.push('Token marked as suspicious.');
+    level = 'warn';
+  }
+
+  const requiresHardGate = isUnlimited || isFarOverBalance;
+
+  return {
+    level,
+    isScamToken,
+    isSuspiciousToken,
+    isUnlimited,
+    isOverBalance,
+    isFarOverBalance,
+    amountRaw,
+    amountFormatted: token?.raw_amount_str ?? null,
+    approveUsdValue,
+    reasons,
+    requiresHardGate,
+  };
+}
+
+export function assessSendRisk(
+  decoded: IDecodedTransactionResponse | null | undefined,
+): {
+  level: ApproveRiskLevel;
+  isScam: boolean;
+  isSuspicious: boolean;
+  reasons: string[];
+} {
+  if (!decoded) {
+    return { level: 'none', isScam: false, isSuspicious: false, reasons: [] };
+  }
+  let isScam = false;
+  let isSuspicious = false;
+  const visit = (token: DeBankToken | undefined) => {
+    if (!token) return;
+    if (token.is_scam) isScam = true;
+    if (token.is_suspicious) isSuspicious = true;
+  };
+  visit(decoded.type_send?.token);
+  for (const token of decoded.balance_change?.send_token_list ?? []) {
+    visit(token);
+  }
+  for (const token of decoded.balance_change?.receive_token_list ?? []) {
+    visit(token);
+  }
+  const reasons: string[] = [];
+  if (isScam) reasons.push('A token in this transaction is flagged as scam.');
+  if (isSuspicious && !isScam) {
+    reasons.push('A token in this transaction is marked as suspicious.');
+  }
+  return {
+    level: isScam ? 'danger' : isSuspicious ? 'warn' : 'none',
+    isScam,
+    isSuspicious,
+    reasons,
+  };
+}
+

--- a/src/utils/approveGuard.ts
+++ b/src/utils/approveGuard.ts
@@ -79,6 +79,7 @@ export interface PermitItemAssessment {
 export function assessPermitRisk(
   permit: NormalizedPermit | null | undefined,
   balanceLookup: (tokenAddress: string) => bigint | null,
+  remoteScamSpender = false,
 ): PermitRiskAssessment {
   const empty: PermitRiskAssessment = {
     level: 'none',
@@ -94,7 +95,9 @@ export function assessPermitRisk(
   let isUnlimited = false;
   let isOverBalance = false;
   let isFarOverBalance = false;
-  const isScamSpender = isKnownDrainerAddress(permit.spender);
+  // Union of server-side check (ScamSniffer + manual list) and the in-app
+  // bundled floor so older arch versions still flag known drainers.
+  const isScamSpender = remoteScamSpender || isKnownDrainerAddress(permit.spender);
   const perItem: PermitItemAssessment[] = [];
 
   for (const item of permit.items) {
@@ -217,7 +220,18 @@ export function approveBannerCopy(risk: ApproveRiskAssessment): ApproveBannerCop
 export function sendBannerCopy(sendRisk: {
   isScam: boolean;
   isSuspicious: boolean;
+  isScamRecipient: boolean;
 }): ApproveBannerCopy {
+  // Recipient flag has the highest priority: sending to a known drainer
+  // typically means immediate fund loss.
+  if (sendRisk.isScamRecipient) {
+    return {
+      level: 'danger',
+      titleKey: 'SCAM_WARNING_TITLE',
+      message:
+        'Recipient address is on our known-drainer list. Funds sent here are usually lost.',
+    };
+  }
   if (sendRisk.isScam) {
     return {
       level: 'danger',
@@ -259,7 +273,11 @@ export function assessApproveRisk(
   const token: DeBankToken | undefined = approval.token;
   const isScamToken = Boolean(token?.is_scam);
   const isSuspiciousToken = Boolean(token?.is_suspicious);
-  const isScamSpender = isKnownDrainerAddress(approval.spender);
+  // Union of two signals so older backends that don't return the field still fall
+  // back to the bundled list. `is_scam_spender` comes from arch's SecurityService
+  // (ScamSniffer + manual list) — broader coverage than the in-app constants.
+  const isScamSpender =
+    Boolean(approval.is_scam_spender) || isKnownDrainerAddress(approval.spender);
 
   const amountRaw =
     safeParseAmount(token?.raw_amount_str) ??
@@ -341,10 +359,17 @@ export function assessSendRisk(
   level: ApproveRiskLevel;
   isScam: boolean;
   isSuspicious: boolean;
+  isScamRecipient: boolean;
   reasons: string[];
 } {
   if (!decoded) {
-    return { level: 'none', isScam: false, isSuspicious: false, reasons: [] };
+    return {
+      level: 'none',
+      isScam: false,
+      isSuspicious: false,
+      isScamRecipient: false,
+      reasons: [],
+    };
   }
   let isScam = false;
   let isSuspicious = false;
@@ -360,15 +385,25 @@ export function assessSendRisk(
   for (const token of decoded.balance_change?.receive_token_list ?? []) {
     visit(token);
   }
+  // Recipient blocklist hit comes from arch's SecurityService check on
+  // `type_send.to_addr`. Bundled drainer list is not consulted here because
+  // it is spender-focused; the server already unions ScamSniffer + manual.
+  const isScamRecipient = Boolean(decoded.type_send?.is_scam_recipient);
   const reasons: string[] = [];
+  if (isScamRecipient) {
+    reasons.push(
+      'Recipient address is on our known-drainer list.',
+    );
+  }
   if (isScam) reasons.push('A token in this transaction is flagged as scam.');
   if (isSuspicious && !isScam) {
     reasons.push('A token in this transaction is marked as suspicious.');
   }
   return {
-    level: isScam ? 'danger' : isSuspicious ? 'warn' : 'none',
+    level: isScamRecipient || isScam ? 'danger' : isSuspicious ? 'warn' : 'none',
     isScam,
     isSuspicious,
+    isScamRecipient,
     reasons,
   };
 }

--- a/src/utils/permitParser.ts
+++ b/src/utils/permitParser.ts
@@ -1,0 +1,196 @@
+const PERMIT2_ADDRESS = '0x000000000022d473030f116ddee9f6b43ac78ba3';
+
+const UINT256_MAX = BigInt(
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+);
+// eslint-disable-next-line no-bitwise
+const UINT160_MAX = (1n << 160n) - 1n;
+const UNLIMITED_THRESHOLD_256 = UINT256_MAX / 2n;
+const UNLIMITED_THRESHOLD_160 = UINT160_MAX / 2n;
+
+export type PermitKind = 'eip2612' | 'permit2-single' | 'permit2-batch';
+
+export interface PermitItem {
+  token: string;
+  tokenSymbol?: string;
+  amount: bigint;
+  isUnlimited: boolean;
+  expiration?: number;
+}
+
+export interface NormalizedPermit {
+  kind: PermitKind;
+  spender: string;
+  owner?: string;
+  chainId?: number;
+  deadline?: number;
+  items: PermitItem[];
+  raw: unknown;
+}
+
+function parseBigIntLoose(value: unknown): bigint | null {
+  if (value === undefined || value === null) return null;
+  try {
+    if (typeof value === 'bigint') return value;
+    if (typeof value === 'number') return BigInt(Math.trunc(value));
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      return trimmed.startsWith('0x') || trimmed.startsWith('0X')
+        ? BigInt(trimmed)
+        : BigInt(trimmed.split('.')[0]);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function parseNumberLoose(value: unknown): number | undefined {
+  const big = parseBigIntLoose(value);
+  if (big === null) return undefined;
+  const num = Number(big);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function lowerOrUndef(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value.trim() || undefined;
+}
+
+export function parseEip712Json(jsonOrObj: unknown): Record<string, unknown> | null {
+  if (jsonOrObj == null) return null;
+  if (typeof jsonOrObj === 'string') {
+    try {
+      return JSON.parse(jsonOrObj);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof jsonOrObj === 'object') {
+    return jsonOrObj as Record<string, unknown>;
+  }
+  return null;
+}
+
+export function parsePermitTypedData(
+  typedDataJsonOrObj: unknown,
+): NormalizedPermit | null {
+  const data = parseEip712Json(typedDataJsonOrObj);
+  if (!data) return null;
+
+  const primaryType = lowerOrUndef(data.primaryType);
+  const domain = (data.domain ?? {}) as Record<string, unknown>;
+  const message = (data.message ?? {}) as Record<string, unknown>;
+  const verifyingContract = lowerOrUndef(domain.verifyingContract)?.toLowerCase();
+  const chainId = parseNumberLoose(domain.chainId);
+
+  if (primaryType === 'permit') {
+    if (verifyingContract === PERMIT2_ADDRESS) {
+      return parsePermit2Single(data, domain, message, chainId);
+    }
+    return parseEip2612(data, domain, message, chainId);
+  }
+  if (primaryType === 'permitsingle') {
+    return parsePermit2Single(data, domain, message, chainId);
+  }
+  if (primaryType === 'permitbatch') {
+    return parsePermit2Batch(data, domain, message, chainId);
+  }
+  return null;
+}
+
+function parseEip2612(
+  raw: unknown,
+  domain: Record<string, unknown>,
+  message: Record<string, unknown>,
+  chainId: number | undefined,
+): NormalizedPermit | null {
+  const tokenContract = lowerOrUndef(domain.verifyingContract);
+  const spender = lowerOrUndef(message.spender);
+  if (!tokenContract || !spender) return null;
+  const amount = parseBigIntLoose(message.value ?? message.allowed);
+  const deadline = parseNumberLoose(message.deadline);
+  if (amount === null) return null;
+  return {
+    kind: 'eip2612',
+    spender,
+    owner: lowerOrUndef(message.owner),
+    chainId,
+    deadline,
+    items: [
+      {
+        token: tokenContract,
+        tokenSymbol: lowerOrUndef(domain.name),
+        amount,
+        isUnlimited: amount >= UNLIMITED_THRESHOLD_256,
+      },
+    ],
+    raw,
+  };
+}
+
+function parsePermit2Single(
+  raw: unknown,
+  domain: Record<string, unknown>,
+  message: Record<string, unknown>,
+  chainId: number | undefined,
+): NormalizedPermit | null {
+  const spender = lowerOrUndef(message.spender);
+  const details = (message.details ?? {}) as Record<string, unknown>;
+  const token = lowerOrUndef(details.token);
+  const amount = parseBigIntLoose(details.amount);
+  if (!spender || !token || amount === null) return null;
+  return {
+    kind: 'permit2-single',
+    spender,
+    chainId,
+    deadline: parseNumberLoose(message.sigDeadline ?? details.expiration),
+    items: [
+      {
+        token,
+        amount,
+        isUnlimited: amount >= UNLIMITED_THRESHOLD_160,
+        expiration: parseNumberLoose(details.expiration),
+      },
+    ],
+    raw,
+  };
+}
+
+function parsePermit2Batch(
+  raw: unknown,
+  domain: Record<string, unknown>,
+  message: Record<string, unknown>,
+  chainId: number | undefined,
+): NormalizedPermit | null {
+  const spender = lowerOrUndef(message.spender);
+  if (!spender) return null;
+  const detailsArr: Record<string, unknown>[] | null = Array.isArray(
+    message.details,
+  )
+    ? (message.details as Record<string, unknown>[])
+    : null;
+  if (!detailsArr || detailsArr.length === 0) return null;
+  const items: PermitItem[] = [];
+  for (const entry of detailsArr) {
+    const token = lowerOrUndef(entry.token);
+    const amount = parseBigIntLoose(entry.amount);
+    if (!token || amount === null) continue;
+    items.push({
+      token,
+      amount,
+      isUnlimited: amount >= UNLIMITED_THRESHOLD_160,
+      expiration: parseNumberLoose(entry.expiration),
+    });
+  }
+  if (items.length === 0) return null;
+  return {
+    kind: 'permit2-batch',
+    spender,
+    chainId,
+    deadline: parseNumberLoose(message.sigDeadline),
+    items,
+    raw,
+  };
+}

--- a/src/utils/permitParser.ts
+++ b/src/utils/permitParser.ts
@@ -13,6 +13,7 @@ export type PermitKind = 'eip2612' | 'permit2-single' | 'permit2-batch';
 export interface PermitItem {
   token: string;
   tokenSymbol?: string;
+  decimals?: number;
   amount: bigint;
   isUnlimited: boolean;
   expiration?: number;
@@ -109,7 +110,13 @@ function parseEip2612(
   const tokenContract = lowerOrUndef(domain.verifyingContract);
   const spender = lowerOrUndef(message.spender);
   if (!tokenContract || !spender) return null;
-  const amount = parseBigIntLoose(message.value ?? message.allowed);
+  const rawAllowed = message.allowed;
+  const amount =
+    typeof rawAllowed === 'boolean'
+      ? rawAllowed
+        ? UINT256_MAX
+        : 0n
+      : parseBigIntLoose(message.value ?? rawAllowed);
   const deadline = parseNumberLoose(message.deadline);
   if (amount === null) return null;
   return {


### PR DESCRIPTION
Active drainer campaign reported by support (stakevaulteth.io → farmeth.io → `0xFaC379E4…10349`) is pulling funds from users via on-chain `approve()` and off-chain EIP-2612 `permit()` signatures. The existing signing modal showed the spender + gas but never displayed the amount, and there was no risk evaluation on the spender, the approval magnitude, or the requesting domain.

This PR adds layered, opt-out-style defenses against the drainer pattern while staying out of the way for legitimate large approvals (Uniswap LP, Aave deposit, etc.).


https://github.com/user-attachments/assets/89ee378b-0eb5-44af-8e2a-ba7f04879b1c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Risk-gated signing UI with an “ignore all” footer and scam-warning banners.
  * Dedicated permit signing modal with per-item details, masked spender, deadlines and balance hints.
  * Hooks to fetch token balances for approval/permit flows and consistent typed-data permit parsing.
  * WalletConnect pairing and in-app browser/send flows block or warn on scam-flagged hosts/recipients.

* **Security Improvements**
  * Curated known-drainer/scam lists plus remote scam-check service.
  * Enhanced approval/permit/send risk evaluation with unlimited/over-balance heuristics and banner copy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CypherD-IO/mobile-app/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->