### PR TITLE
feat(coinbase): use secure-init session token for onramp URLOA

### DIFF
--- a/src/containers/FundCardScreen/cbpay.tsx
+++ b/src/containers/FundCardScreen/cbpay.tsx
@@ -19,49 +19,26 @@ export type SupportedBlockchains =
   | 'ethereum'
   | 'polygon';
 
-export interface DestinationWallet {
-  /* Destination address where the purchased assets will be sent. */
-  address: string;
-  /** List of networks enabled for the associated address. All assets available per network are displayed to the user. */
-  blockchains?: string[];
-  /** List of assets enabled for the associated address. They are appended to the available list of assets. */
-  assets?: string[];
-  /** Restrict the networks available for the associated assets. */
-  supportedNetworks?: string[];
-}
-
-export interface OnRampAppParams {
-  /** The destination wallets supported by your application (BTC, ETH, etc). */
-  destinationWallets: DestinationWallet[];
-  /** The preset input amount as a crypto value. i.e. 0.1 ETH. This will be the initial default for all cryptocurrencies. */
-  presetCryptoAmount?: number;
-  /**
-   * The preset input amount as a fiat value. i.e. 15 USD.
-   * This will be the initial default for all cryptocurrencies. Ignored if presetCryptoAmount is also set.
-   * Also note this only works for a subset of fiat currencies: USD, CAD, GBP, EUR
-   * */
-  presetFiatAmount?: number;
-  /** The default network that should be selected when multiple networks are present. */
-  defaultNetwork?: string;
-}
-
-export type GenerateOnRampURLOptions = {
-  appId: string;
+export interface GenerateOnRampURLOptions {
+  /** One-time session token minted by our backend. */
+  sessionToken: string;
   host?: string;
-} & OnRampAppParams;
+  /** Optional UX presets — safe to pass alongside sessionToken. */
+  defaultNetwork?: string;
+  defaultAsset?: string;
+  presetCryptoAmount?: number;
+  presetFiatAmount?: number;
+  fiatCurrency?: string;
+}
 
 export const generateOnRampURL = ({
   host = 'https://pay.coinbase.com',
-  destinationWallets,
+  sessionToken,
   ...otherParams
 }: GenerateOnRampURLOptions): string => {
   const url = new URL(host);
   url.pathname = '/buy/select-asset';
-
-  url.searchParams.append(
-    'destinationWallets',
-    JSON.stringify(destinationWallets),
-  );
+  url.searchParams.append('sessionToken', sessionToken);
 
   (Object.keys(otherParams) as Array<keyof typeof otherParams>).forEach(key => {
     const value = otherParams[key];
@@ -85,7 +62,7 @@ export default function CoinbasePay({ route, navigation }) {
       : ethereum.address;
   const { showModal, hideModal } = useGlobalModalContext();
   const [onRampURL, setOnRampURL] = useState<string>('');
-  const { getWithAuth } = useAxios();
+  const { postWithAuth } = useAxios();
 
   useEffect(() => {
     void logAnalyticsToFirebase(AnalyticEvent.INSIDE_COINBASE_PAY);
@@ -140,36 +117,49 @@ export default function CoinbasePay({ route, navigation }) {
     }, MODAL_HIDE_TIMEOUT);
   }
 
+  const showCbError = () => {
+    showModal('state', {
+      type: 'error',
+      title: t('COINBASE_LINK_ERROR'),
+      description: t('CONTACT_CYPHERD_SUPPORT'),
+      onSuccess: onModalHide,
+      onFailure: hideModal,
+    });
+  };
+
   const getCbCreds = async () => {
     try {
-      const resp = await getWithAuth('/v1/authentication/creds/cb');
-      if (!resp.error) {
-        const { data } = resp;
+      const resp = await postWithAuth(
+        '/v1/authentication/creds/cb/session-token',
+        {
+          address: addr,
+          blockchains: blockchain,
+          // assets: ['ETH', 'USDC'], // optional — omit to allow all assets for the network
+        },
+      );
+      if (!resp.error && resp.data?.token) {
         const rampURL = generateOnRampURL({
-          host: data.host,
-          appId: data.appId,
-          destinationWallets: [
-            {
-              address: addr,
-              blockchains: blockchain,
-            },
-          ],
+          host: resp.data.host, // falls back to default inside generateOnRampURL if undefined
+          sessionToken: resp.data.token,
         });
         setOnRampURL(rampURL);
+      } else {
+        showCbError();
       }
     } catch (e) {
-      showModal('state', {
-        type: 'error',
-        title: t('COINBASE_LINK_ERROR'),
-        description: t('CONTACT_CYPHERD_SUPPORT'),
-        onSuccess: onModalHide,
-        onFailure: hideModal,
-      });
+      showCbError();
       Sentry.captureException('coinbase_pay_generate_url_error');
     }
   };
 
-  void getCbCreds();
+  useEffect(() => {
+    // Only mint a token once we have a resolved address + supported chain.
+    // addr is stable for a given screen open; keep deps minimal so we don't
+    // re-mint a single-use token. The screen remounts on re-navigation.
+    if (addr && Array.isArray(blockchain)) {
+      void getCbCreds();
+    }
+  }, [addr]);
 
   return (
     <CyDView className={'h-full w-full'}>


### PR DESCRIPTION
  Coinbase mandates secure initialization (2025-07-31): every
  Onramp URL
  must carry a one-time sessionToken minted server-side. The old
  public
  appId + destinationWallets-in-URL flow is rejected.

  - generateOnRampURL now appends sessionToken instead of destinationWallets/appId
  - getCbCreds POSTs { address, blockchains } to /v1/authentication/creds/cb/session-token and builds the URL from the returned token (host falls back to the default)
  - factor the error modal into showCbError(), reused on   and catch
  - fix: mint the token once in a useEffect instead of on every
  render
    (session tokens are single-use and rate-limited)
  - drop the now-unused DestinationWallet / OnRampAppParams types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Coinbase on-ramp authentication mechanism with session-based tokens.
  * Added localized error handling to display user-friendly notifications if on-ramp initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->